### PR TITLE
IRIDA compatible directory output with messages_en.properties and proper filenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ Execute standalone JAR with `java`:
 
 ## Examples
 
-    $ java -jar target/uberjar/irida-wf-ga2xml-0.1.0-SNAPSHOT-standalone.jar \
+    $ java -jar irida-wf-ga2xml-1.0.0-SNAPSHOT-standalone.jar \
         -t phylogenomics \ 
         -W 1.0.1 \ 
         -m \
         -i test/data/snvphyl-1.0.1-workflow.ga \
-        -n snvphyl > snvphyl-wf.xml
+        -n snvphyl
+        -o /tmp
 
 Output:
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/data.json "0.2.6"]
-                 [org.clojure/data.xml "0.2.0-alpha5"]]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [org.clojure/data.zip "0.1.2"]]
   :main ^:skip-aot irida-wf-ga2xml.main
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject irida-wf-ga2xml "0.1.1-SNAPSHOT"
+(defproject irida-wf-ga2xml "1.0.0-SNAPSHOT"
   :description "Parse a Galaxy workflow ga JSON file and output an IRIDA workflow description XML file"
   :url "https://github.com/phac-nml/irida-wf-ga2xml"
   :license {:name "Apache License 2.0"
@@ -7,7 +7,8 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.xml "0.2.0-alpha5"]
-                 [org.clojure/data.zip "0.1.2"]]
+                 [org.clojure/data.zip "0.1.2"]
+                 [com.taoensso/timbre "4.10.0"]]
   :main ^:skip-aot irida-wf-ga2xml.main
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -117,7 +117,8 @@
   (let [ga-map (parse-ga path)
         {:strs [name annotation]} ga-map
         _ (info (str "Parsed Galaxy workflow file with name='" name "' and annotation/description='" annotation "'"))
-        name (if wf-name wf-name name)
+        name (safe-workflow-name (if wf-name wf-name name))
+        _ (info (str "Using worklfow name='" name "'"))
         input (input-steps ga-map)
         _ (info (count input) "input steps in workflow")
         steps (tool-steps ga-map)
@@ -127,7 +128,8 @@
                                                     :get-param-labels? output-messages?
                                                     :extra-tool-param-attrs? extra-tool-param-attrs?))
                              (filter not-empty))
-        out {:xml-vec
+        out {:name name
+             :xml-vec
              [:iridaWorkflow
               [:id (uuid)]
               [:name name]

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -1,11 +1,12 @@
 (ns irida-wf-ga2xml.core
   (:require
     [irida-wf-ga2xml.util :refer :all]
-    [irida-wf-ga2xml.messages :refer [tool-step->param-attr-map
-                                      get-tool-param-messages
-                                      default-workflow-messages
-                                      prepend-param-details]]
-    [clojure.data.json :as json]))
+    [irida-wf-ga2xml.messages :as msgs]
+    [clojure.data.json :as json]
+    [taoensso.timbre :as timbre
+     :refer [log trace debug info warn error fatal report
+             logf tracef debugf infof warnf errorf fatalf reportf
+             spy get-env]]))
 
 (def excluded-keys #{"__page__"
                      "__class__"
@@ -18,14 +19,16 @@
 (defn get-step-outputs
   "Get all workflow step outputs that have been renamed. A workflow step output must be renamed
   to signify that it will be returned as an output from the workflow."
-  [step]
+  [step & {:keys [remove-file-ext?] :or {remove-file-ext? false}}]
   (if-let [outputs (get step "post_job_actions")]
     (let [renames (->> outputs
                        vals
                        (filter #(= (get % "action_type") "RenameDatasetAction"))
                        (map (fn [{:strs [action_arguments]}]
                               (let [filename (get action_arguments "newname")]
-                                {:name     (rm-file-ext filename)
+                                {:name     (if remove-file-ext?
+                                             (rm-file-ext filename)
+                                             filename)
                                  :fileName filename}))))]
       (map #(conj [:output] %) renames))))
 
@@ -53,21 +56,37 @@
 (defn tool-params-vec
   "Return a vector of all tool parameters for a workflow `step` in a format that will
   serialize into the expected IRIDA XML format for tool parameters."
-  [step & {:keys [get-param-labels?] :or {get-param-labels? true}}]
+  [step & {:keys [get-param-labels?
+                  extra-tool-param-attrs?]
+           :or   {get-param-labels?       true
+                  extra-tool-param-attrs? false}}]
   (let [{:strs [tool_id id]} step
         {:keys [name]} (tool-id->repo-info tool_id)
         params (tool-params-map step)
+        param-attrs (if get-param-labels?
+                      (msgs/get-tool-param-values step (keys params))
+                      nil)
         xml-vec (vec (map (fn [[k v]]
-                            [:parameter
-                             {:name         (parameter-name (if name name tool_id) id k)
-                              :defaultValue v}
-                             [:toolParameter
-                              {:toolId        tool_id
-                               :parameterName k}]])
+                            (let [base-attrs {:toolId        tool_id
+                                              :parameterName k}
+                                  extra-attrs (if extra-tool-param-attrs?
+                                                (map (fn [x]
+                                                       {x
+                                                        (get-in param-attrs [:attrs x k])})
+                                                     (keys (:attrs param-attrs)))
+                                                nil)]
+                              [:parameter
+                               {:name         (parameter-name (if name name tool_id) id k)
+                                :defaultValue v}
+                               [:toolParameter
+                                (->> (apply conj base-attrs extra-attrs)
+                                     (remove (fn [[_ v]] (nil? v)))
+                                     (into {}))
+                                ]]))
                           params))
         out {:xml-vec xml-vec}]
     (if (and get-param-labels? (not-empty xml-vec))
-      (conj out (get-tool-param-messages step (keys params)))
+      (conj out param-attrs)
       out)))
 
 (defn to-wf-vec
@@ -85,20 +104,29 @@
                           ^String wf-version
                           ^String analysis-type
                           ^String wf-name
-                          ^Boolean output-messages?]
-                   :or   {single-sample? true
-                          wf-version     "0.1.0"
-                          analysis-type  "DEFAULT"
-                          wf-name        nil
-                          output-messages? true}}]
-  (let [j (parse-ga path)
-        {:strs [name annotation]} j
+                          ^Boolean output-messages?
+                          ^Boolean extra-tool-param-attrs?
+                          ^Boolean remove-output-name-file-ext?]
+                   :or   {single-sample?               true
+                          wf-version                   "0.1.0"
+                          analysis-type                "DEFAULT"
+                          wf-name                      nil
+                          output-messages?             true
+                          extra-tool-param-attrs?      false
+                          remove-output-name-file-ext? false}}]
+  (let [ga-map (parse-ga path)
+        {:strs [name annotation]} ga-map
+        _ (info (str "Parsed Galaxy workflow file with name='" name "' and annotation/description='" annotation "'"))
         name (if wf-name wf-name name)
-        input (input-steps j)
-        steps (tool-steps j)
+        input (input-steps ga-map)
+        _ (info (count input) "input steps in workflow")
+        steps (tool-steps ga-map)
+        _ (info (count steps) "tool execution steps in workflow")
         parameters-maps (->> steps
-                       (map #(tool-params-vec % :get-param-labels? output-messages?))
-                       (filter not-empty))
+                             (map #(tool-params-vec %
+                                                    :get-param-labels? output-messages?
+                                                    :extra-tool-param-attrs? extra-tool-param-attrs?))
+                             (filter not-empty))
         out {:xml-vec
              [:iridaWorkflow
               [:id (uuid)]
@@ -108,18 +136,23 @@
               [:inputs
                (when (paired? input)
                  [:sequenceReadsPaired (input-name input)])
-               (when (needs-reference? j)
+               (when (needs-reference? ga-map)
                  [:reference "reference"])
                [:requiresSingleSample (str single-sample?)]]
               (vcons :parameters (vec (mapcat :xml-vec parameters-maps)))
-              (vcons :outputs (vec (filter not-empty (mapcat get-step-outputs steps))))
+              (vcons :outputs (->> steps
+                                   (mapcat
+                                     #(get-step-outputs %
+                                                        :remove-file-ext? remove-output-name-file-ext?))
+                                   (filter not-empty)
+                                   (vec)))
               (vcons :toolRepositories (vec (set (remove nil? (map tool-repo steps)))))]}
         ]
     (if output-messages?
-      (conj out {:props (conj [(default-workflow-messages name analysis-type annotation)]
+      (conj out {:props (conj [(msgs/default-workflow-messages name analysis-type annotation)]
                               (->> parameters-maps
                                    (map :props)
-                                   (map #(prepend-param-details name %))
+                                   (map #(msgs/prepend-param-details name %))
                                    (remove nil?)
                                    (remove empty?)
                                    (vec)))})

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -1,6 +1,10 @@
 (ns irida-wf-ga2xml.core
   (:require
     [irida-wf-ga2xml.util :refer :all]
+    [irida-wf-ga2xml.messages :refer [tool-step->param-attr-map
+                                      get-tool-param-messages
+                                      default-workflow-messages
+                                      prepend-param-details]]
     [clojure.data.json :as json]))
 
 (def excluded-keys #{"__page__"
@@ -10,48 +14,6 @@
                      "options"
                      "input"
                      "outputs"})
-
-(def tool-id-repos-pattern (re-pattern "/repos/"))
-(def slash-pattern (re-pattern "/"))
-
-(defn dundered?
-  "Is `x` wrapped in double underscores?"
-  [x]
-  (try
-    (boolean (re-matches #"^__.*__$" x))
-    (catch Exception _
-      false)))
-
-(defn try-parse-json [x]
-  "Try to parse `x` as JSON string."
-  (try
-    (json/read-str x)
-    (catch Exception _
-      x)))
-
-(defn recur-descend-maps
-  "Flatten a nested map with '.' delimited keys to scalar values.
-  e.g {\"a\" {\"b\" {\"c\" 1} \"d\" 2} \"e\" 3}
-  will produce the following map
-  {\"a.b.c\" 1 \"a.d\" 2 \"e\" 3}"
-  [prev-key x]
-  (if (map? x)
-    (map (fn [[k v]]
-           (if (map? x)
-             (recur-descend-maps (str prev-key "." k) v)
-             {(str prev-key "." k) v}))
-         (remove (fn [[k _]] (dundered? k)) x))
-    {prev-key x}))
-
-(defn tool-id->repo-info
-  "Get Tool Shed repo information from the Galaxy tool id if possible.
-  Check if the tool id contains '/repos/' string."
-  [tool-id]
-  (if (re-find tool-id-repos-pattern tool-id)
-    (let [[url & owner-tool-rest] (clojure.string/split tool-id tool-id-repos-pattern)
-          [owner name & _] (clojure.string/split (first owner-tool-rest) slash-pattern)]
-      (kw-quote url owner name))
-    {:url nil :owner nil :name nil}))
 
 (defn get-step-outputs
   "Get all workflow step outputs that have been renamed. A workflow step output must be renamed
@@ -66,44 +28,6 @@
                                 {:name     (rm-file-ext filename)
                                  :fileName filename}))))]
       (map #(conj [:output] %) renames))))
-
-(defn tool-repo
-  "Get tool repository information for the tool at the given `step`.
-  If no 'tool_shed_repository' map exists in the `step` map, then try to get
-  the latest tool revision from the tool's Galaxy Tool Shed.
-  A warning comment is added if the latest revision is used."
-  [step]
-  (let [{:strs [tool_id
-                tool_shed_repository]} step
-        {:strs [changeset_revision owner tool_shed]} tool_shed_repository
-        url-owner-map (tool-id->repo-info tool_id)
-        tool_shed (if tool_shed
-                    tool_shed
-                    (:url url-owner-map))
-        name (:name url-owner-map)
-        owner (if owner
-                owner
-                (:owner url-owner-map))
-        url (if (has-http? tool_shed)
-              tool_shed
-              (str "https://" tool_shed))
-        revision (if changeset_revision
-                   changeset_revision
-                   ; try to get the tool revision via https then http if that fails
-                   (if-let [r (revision-from-url (galaxy-shed-url tool_id))]
-                     r
-                     (revision-from-url (galaxy-shed-url tool_id :https? false))))
-        repo-info (vec (kw-quote name owner url revision))]
-    (if name
-      (vcons
-        :repository
-        (if changeset_revision
-          repo-info
-          (conj repo-info
-                [:-comment
-                 (str "WARNING: Latest revision fetched from "
-                      (galaxy-shed-url tool_id))])))
-      nil)))
 
 (defn tool-params-map
   "Get the tool parameters for a workflow step from the `tool_state` map.
@@ -129,20 +53,22 @@
 (defn tool-params-vec
   "Return a vector of all tool parameters for a workflow `step` in a format that will
   serialize into the expected IRIDA XML format for tool parameters."
-  [step]
+  [step & {:keys [get-param-labels?] :or {get-param-labels? true}}]
   (let [{:strs [tool_id id]} step
         {:keys [name]} (tool-id->repo-info tool_id)
-        params (tool-params-map step)]
-    (vec (map (fn [[k v]]
-                [:parameter {:name         (str (if name
-                                                  name
-                                                  tool_id)
-                                                "-" id
-                                                "-" k)
-                             :defaultValue v}
-                 [:toolParameter {:toolId        tool_id
-                                  :parameterName k}]])
-              params))))
+        params (tool-params-map step)
+        xml-vec (vec (map (fn [[k v]]
+                            [:parameter
+                             {:name         (parameter-name (if name name tool_id) id k)
+                              :defaultValue v}
+                             [:toolParameter
+                              {:toolId        tool_id
+                               :parameterName k}]])
+                          params))
+        out {:xml-vec xml-vec}]
+    (if (and get-param-labels? (not-empty xml-vec))
+      (conj out (get-tool-param-messages step (keys params)))
+      out)))
 
 (defn to-wf-vec
   "Build an IRIDA workflow description vector from a Galaxy workflow ga JSON file.
@@ -158,26 +84,43 @@
   [^String path & {:keys [^Boolean single-sample?
                           ^String wf-version
                           ^String analysis-type
-                          ^String wf-name]
+                          ^String wf-name
+                          ^Boolean output-messages?]
                    :or   {single-sample? true
                           wf-version     "0.1.0"
                           analysis-type  "DEFAULT"
-                          wf-name nil}}]
+                          wf-name        nil
+                          output-messages? true}}]
   (let [j (parse-ga path)
-        {:strs [name]} j
+        {:strs [name annotation]} j
+        name (if wf-name wf-name name)
         input (input-steps j)
-        steps (tool-steps j)]
-    [:iridaWorkflow
-     [:id (uuid)]
-     [:name (if wf-name wf-name name)]
-     [:version wf-version]
-     [:analysisType analysis-type]
-     [:inputs
-      (when (paired? input)
-        [:sequenceReadsPaired (input-name input)])
-      (when (needs-reference? j)
-        [:reference "reference"])
-      [:requiresSingleSample (str single-sample?)]]
-     (vcons :parameters (vec (filter not-empty (mapcat tool-params-vec steps))))
-     (vcons :outputs (vec (filter not-empty (mapcat get-step-outputs steps))))
-     (vcons :toolRepositories (vec (set (remove nil? (map tool-repo steps)))))]))
+        steps (tool-steps j)
+        parameters-maps (->> steps
+                       (map #(tool-params-vec % :get-param-labels? output-messages?))
+                       (filter not-empty))
+        out {:xml-vec
+             [:iridaWorkflow
+              [:id (uuid)]
+              [:name name]
+              [:version wf-version]
+              [:analysisType analysis-type]
+              [:inputs
+               (when (paired? input)
+                 [:sequenceReadsPaired (input-name input)])
+               (when (needs-reference? j)
+                 [:reference "reference"])
+               [:requiresSingleSample (str single-sample?)]]
+              (vcons :parameters (vec (mapcat :xml-vec parameters-maps)))
+              (vcons :outputs (vec (filter not-empty (mapcat get-step-outputs steps))))
+              (vcons :toolRepositories (vec (set (remove nil? (map tool-repo steps)))))]}
+        ]
+    (if output-messages?
+      (conj out {:props (conj [(default-workflow-messages name analysis-type annotation)]
+                              (->> parameters-maps
+                                   (map :props)
+                                   (map #(prepend-param-details name %))
+                                   (remove nil?)
+                                   (remove empty?)
+                                   (vec)))})
+      out)))

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -110,7 +110,7 @@
             _ (trace "irida-wf-map: " irida-wf-map)
             xml-str (vec->indented-xml (:xml-vec irida-wf-map))]
         (if outdir
-          (let [file-with-base (partial io/file outdir workflow-name workflow-version)
+          (let [file-with-base (partial io/file outdir (:name irida-wf-map) workflow-version)
                 irida-xml-filename (.toString (file-with-base "irida_workflow.xml"))
                 ga-file-dest (.toString (file-with-base "irida_workflow_structure.ga"))]
             (io/make-parents irida-xml-filename)

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -5,8 +5,15 @@
     [irida-wf-ga2xml.core :refer [to-wf-vec]]
     [irida-wf-ga2xml.util :refer [vec->indented-xml]]
     [irida-wf-ga2xml.messages :as msgs]
-    [clojure.java.io :as io])
+    [clojure.java.io :as io]
+    [taoensso.timbre :as timbre
+     :refer [log  trace  debug  info  warn  error  fatal  report
+             logf tracef debugf infof warnf errorf fatalf reportf
+             spy get-env]])
   (:gen-class))
+
+(def --program-- "irida-wf-ga2xml")
+(def --version-- "1.0.0")
 
 (def cli-options
   [["-n" "--workflow-name WORKFLOW_NAME" "Workflow name (default is to extract name from workflow input file)"
@@ -18,16 +25,28 @@
     :default "0.1.0"
     :validate [#(re-matches #"[\d\.]+" %) "Can only contain numbers and periods"]]
    ["-o" "--outdir OUPUT_DIRECTORY"
-    "Output directory; where to create the <workflow_name>/<version>/<files> directory structure"
+    "Output directory; where to create the <workflow-name>/<workflow-version>/ directory structure and write the 'irida_workflow.xml', 'irida_workflow_structure.ga' and 'messages_en.properties' files"
     :default nil]
    ["-m" "--multi-sample" "Multiple sample workflow; not a single sample workflow"]
    ["-i" "--input INPUT" "Galaxy workflow ga JSON format file"]
+   ["-x" "--extra-tool-param-attrs" "Save extra toolParameter attributes [\"label\", \"type\"] to XML"]
+   [nil "--remove-output-name-file-ext" "Remove file extension in workflow output names?"]
+   ["-v" "--verbosity" "Verbosity level"
+    :id :verbosity
+    :default 0
+    :assoc-fn (fn [m k _] (update-in m [k] inc))]
+   ["-V" "--version" "Display version"]
    ["-h" "--help"]])
 
+(defn program-version []
+  (str --program-- " v" --version--))
+
 (defn usage [options-summary]
-  (->> ["Output IRIDA workflow XML file from Galaxy Workflow ga JSON file"
+  (->> [(str
+          (program-version)
+          ": Output an IRIDA workflow directory with irida_structure.xml, messages_en.properties and irida_workflow_structure.ga files from a Galaxy Workflow *.ga JSON file")
         ""
-        "Usage: irida_wf_ga2xml [options] > irida_workflow.xml"
+        (str "Usage: " --program-- " [options]")
         ""
         "Options:"
         options-summary
@@ -44,6 +63,7 @@
         {:keys [options arguments errors summary]} parsed-args]
     (cond
       (:help options) {:exit-message (usage summary) :ok? true}
+      (:version options) {:exit-message (program-version) :ok? true}
       errors {:exit-message (error-msg errors)}
       (:input options) {:action "parse" :options options}
       :else {:exit-message (usage summary)}
@@ -52,6 +72,15 @@
 (defn exit [status msg]
   (println msg)
   (System/exit status))
+
+(defn verbosity->logging-level
+  [^Long verbosity]
+  (get (->> timbre/-levels-vec
+            (reverse)
+            ; drop :report and :fatal - verbosity 0 == :error level
+            (drop 2)
+            (vec))
+       verbosity))
 
 (defn -main
   ""
@@ -64,12 +93,21 @@
                     outdir
                     workflow-version
                     multi-sample
-                    workflow-name]} options
+                    workflow-name
+                    extra-tool-param-attrs
+                    remove-output-name-file-ext
+                    verbosity]} options
+            _ (timbre/set-level! (verbosity->logging-level verbosity))
+            _ (trace "Options" options)
+            _ (info "Parsing " input " Galaxy workflow file. Creating irida_workflow.xml with workflow name '" workflow-name "' and version '" workflow-version "'.")
             irida-wf-map (to-wf-vec input
                                     :wf-version workflow-version
                                     :analysis-type analysis-type
                                     :single-sample? (not multi-sample)
-                                    :wf-name workflow-name)
+                                    :wf-name workflow-name
+                                    :extra-tool-param-attrs? (boolean extra-tool-param-attrs)
+                                    :remove-output-name-file-ext? (boolean remove-output-name-file-ext))
+            _ (trace "irida-wf-map: " irida-wf-map)
             xml-str (vec->indented-xml (:xml-vec irida-wf-map))]
         (if outdir
           (let [file-with-base (partial io/file outdir workflow-name workflow-version)
@@ -78,13 +116,17 @@
             (io/make-parents irida-xml-filename)
             (io/make-parents ga-file-dest)
             (spit irida-xml-filename xml-str)
-            (println "Wrote workflow XML to " irida-xml-filename)
+            (info "Wrote workflow XML to " irida-xml-filename)
             (spit ga-file-dest (slurp input))
-            (println "Wrote Galaxy workflow *.ga file to " ga-file-dest)
+            (info "Wrote Galaxy workflow *.ga file to " ga-file-dest)
             (if-let [[main-props tool-param-props] (:props irida-wf-map)]
               (let [msg-props-file (.toString (file-with-base "messages_en.properties"))]
+                (trace "main workflow properties" main-props)
+                (trace "tool parameter properties" tool-param-props)
                 (io/make-parents msg-props-file)
                 (msgs/write-props msg-props-file main-props tool-param-props)
-                (println "Wrote IRIDA messages to " msg-props-file))))
-          ;; no outdir specified? print to stdout
-          (println xml-str))))))
+                (info "Wrote IRIDA messages to " msg-props-file))
+              (warn "No messages_en.properties written!")))
+          (do
+            (warn "No output directory specified. Printing irida_structure.xml to standard output")
+            (println xml-str)))))))

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -1,0 +1,236 @@
+(ns irida-wf-ga2xml.messages
+  "Functions for getting messages.properties entries given a Galaxy workflow spec file.
+  - tool parameter information
+  - workflow description"
+  (:require
+    [irida-wf-ga2xml.util :as util]
+    [clojure.zip :as zip :refer [children xml-zip]]
+    [clojure.data.xml :as xml]
+    [clojure.data.zip.xml :as zip-xml :refer [xml-> attr]]
+    [clojure.java.io :as io])
+  (:import
+    [java.util Properties Map ArrayList]
+    [java.io File]
+    (clojure.lang PersistentVector)))
+
+(defn get-repo-info
+  "Get tool repository informatio map given Galaxy workflow `tool-step` map.
+
+  Returns map with keys:
+  - `:name`: tool name (e.g. 'prokka')
+  - `:owner`: owner name (e.g. 'uic')
+  - `:url`: base toolshed url (e.g. 'https://toolshed.g2.bx.psu.edu')
+  - `:revision`: tool revision hash string (e.g. 'eaee459f3d69')
+  "
+  [tool-step]
+  (into {} (rest (util/tool-repo tool-step))))
+
+
+(defn get-toolshed-browse-html
+  "Get the HTML for a Galaxy tool's toolshed browse page given some `repo-info`.
+
+  `repo-info` is a map with keys:
+   - `:name`: tool name (e.g. 'prokka')
+   - `:owner`: owner name (e.g. 'uic')
+   - `:url`: base toolshed url (e.g. 'https://toolshed.g2.bx.psu.edu')
+   - `:revision`: tool revision hash string (e.g. 'eaee459f3d69')
+   "
+  [repo-info]
+  (let [{:keys [name owner url revision]} repo-info]
+    (slurp (str url "/repos/" owner "/" name "/file/" revision))))
+
+(defn xml-filename
+  [html]
+  (if-let [[_ filename] (re-find (re-pattern "class=\"filename\">\\s*<a href=\"\\S*\\/repos\\/\\w+\\/\\w+\\/file\\/\\w+\\/(\\w+\\.xml)\"") html)]
+    filename
+    nil))
+
+
+(defn raw-file-xml-url
+  "Get the raw XML file URL given `repo-info` map and `filename` string.
+
+   Example:
+   ```clj
+   (raw-file-xml-url {:name \"sistr_cmd\"
+                      :owner \"nml\"
+                      :revision \"5c8ff92e38a9\"
+                      :url \"https://toolshed.g2.bx.psu.edu\"}
+                      \"sistr_cmd.xml\")
+   ;;=> \"https://toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/raw-file/5c8ff92e38a9/sistr_cmd.xml\""
+  [repo-info filename]
+  (let [{:keys [name url owner revision]} repo-info]
+    (str url "/repos/" owner "/" name "/raw-file/" revision "/" filename)))
+
+
+(defn xml-url->zipper
+  "Read and parse an XML file from a `url` and return a zipper for the parsed XML starting at the root element."
+  [url]
+  (-> url
+      slurp
+      xml/parse-str
+      zip/xml-zip))
+
+(defn name-kw
+  "Get an XML `node` element's :name attribute as a keyword."
+  [node]
+  (keyword (attr node :name)))
+
+(defn get-param-values
+  "Given an Galaxy tool XML `zipper`, get potentially nested map of param tag name attribute to `get-attr` attribute values (default :label).
+
+  This function recursively descends into :section and :conditional tags to search for :param tags to extract :name and :label (or other attrs) from. The potentially nested structure of the tool XML is reflected in the returned map.
+
+  Examples:
+  Given the tool XML for [biohansel](https://toolshed.g2.bx.psu.edu/repos/nml/bio_hansel/raw-file/4654c51dae72/bio_hansel.xml) and with `:get-attr :type`, returns the following map:
+
+  ```clj
+  {:kmer_vals {:kmer_min \"integer\"
+               :kmer_max \"integer\"}
+   :qc_vals {:low_cov_depth_freq \"integer\"
+             :min_ambiguous_tiles \"integer\"
+             :max_missing_tiles \"float\"
+             :max_intermediate_tiles \"float\"
+             :low_coverage_warning \"integer\"}
+   :dev_args {:use_json \"boolean\"}
+   :input {:type \"select\"
+           :fasta \"data\"
+           :forward \"data\"
+           :reverse \"data\"
+           :single \"data\"
+           :paired_collection \"data_collection\"}
+   :type_of_scheme {:scheme_type \"select\", :scheme_input \"data\"}}
+  ```
+  "
+  [zipper & {:keys [tag-search get-attr]
+             :or   {tag-search [:tool :inputs]
+                    get-attr   :label}}]
+  (letfn [(descend-children [el] (into {} (->>
+                                            (for [x (children el)]
+                                              (if (= (class x) String)
+                                                nil
+                                                (get-param-values (xml-zip x) :tag-search [] :get-attr get-attr)))
+                                            (remove nil?)
+                                            (flatten))))
+          (iter-non-param-elements [tag-kw]
+            (for [el (apply (partial xml-> zipper) (conj tag-search tag-kw))]
+              {(name-kw el)
+               (descend-children el)}))]
+    (let [zippart (partial xml-> zipper)
+          params (for [param (apply zippart (conj tag-search :param))]
+                   {(name-kw param)
+                    (attr param get-attr)})
+          sections (iter-non-param-elements :section)
+          conditionals (iter-non-param-elements :conditional)]
+      (into {} (concat params sections conditionals)))))
+
+
+
+
+(defn flatten-param-values-map
+  "Flatten a nested tool param values map.
+
+  Example:
+  ```clj
+  (flatten-param-values-map
+    {:section {:param1 \"A\"
+               :param2 \"B\"}
+     :conditional {:param3 \"C\"}
+                   :param4 \"D\"})
+  ;;=> {\"section.param1\" \"A\", \"section.param2\" \"B\", \"conditional.param3\" \"C\", \"param4\" \"D\"}
+  "
+  [m]
+  (->> m
+       (remove (fn [[_ v]] (nil? v)))
+       (mapcat (fn [[k v]]
+                 (let [str-k (util/kw->str k)]
+                   (if (map? v)
+                     (flatten (util/recur-descend-maps str-k v))
+                     {str-k v}))))
+       (into {})
+       (filter (fn [[_ v]] (string? v)))
+       (into {})))
+
+(defn repo-info->param-attr-map
+  [repo-info & {:keys [get-attr]
+                :or   {get-attr :label}}]
+  (let [zipper (->> repo-info
+                    (get-toolshed-browse-html)
+                    (xml-filename)
+                    (raw-file-xml-url repo-info)
+                    (xml-url->zipper))]
+    (-> zipper
+        (get-param-values :get-attr get-attr)
+        (flatten-param-values-map))))
+
+(defn tool-step->param-attr-map
+  [tool-step & {:keys [get-attr]
+                :or   {get-attr :label}}]
+  (repo-info->param-attr-map (get-repo-info tool-step)))
+
+(defn tool-param-properties-key
+  [tool-name step-id [param-name param-label]]
+  [(util/parameter-name tool-name step-id param-name)
+   param-label])
+
+(defn get-tool-param-messages
+  "Given a tool `step`, get the tool param label messages from the Galaxy tool
+  XML file param key names specified in `param-names`.
+  Returns a map of `{:props {:param-key \"param label value\" ...}}`"
+  [step param-names]
+  (let [{:strs [tool_id id]} step
+        label-map (tool-step->param-attr-map step)
+        repo-info (get-repo-info step)
+        {:keys [name]} repo-info
+        label-map-prop-keys (into {} (map #(tool-param-properties-key
+                                             (if name name tool_id)
+                                             id
+                                             %)
+                                          label-map))
+        param-names (map #(util/parameter-name (if name name tool_id) id %) param-names)]
+    {:props (->> param-names
+                 (map #(find label-map-prop-keys %))
+                 (remove nil?)
+                 (into {}))}))
+
+
+(defn default-workflow-messages [name analysis-type description]
+  {(str "workflow." analysis-type ".title")       (str name " Pipeline")
+   (str "workflow." analysis-type ".description") description
+   (str "pipeline.title." name)                   (str "Pipelines - " name)
+   (str "pipeline.h1." name)                      (str name " Pipeline")
+   (str "pipeline.parameters.modal-title." name)  (str name " Pipeline Parameters")})
+
+
+(defn prepend-param-details
+  "Prepend required tool parameter key prefixes for output to IRIDA compatible
+  messages.properties.
+  `wf-name` is the workflow name.
+  `props` is a map of properties keys and values.
+  Returns a map of properties keys with proper prefixes."
+  [wf-name props]
+  (into {} (map (fn [[k v]]
+                  {(str "pipeline.parameters." wf-name "." k)
+                   v})
+                props)))
+
+
+(defn ^Properties map->properties
+  [^Map m]
+  (let [p (Properties.)]
+    (doseq [[k v] m]
+      (.setProperty p (name (str k)) (str v)))
+    p))
+
+
+(defn write-props
+  "Write workflow info and tool parameter properties to an `outfile`.
+  `main-props` is a map with the workflow info properties.
+  `tool-param-props` is a vector of maps with tool specific parameter properties."
+  [^String outfile
+   ^Map main-props
+   ^PersistentVector tool-param-props]
+  (with-open [w (io/writer outfile)]
+    (.store (map->properties main-props) w "Pipeline Info Properties"))
+  (doseq [m tool-param-props]
+    (with-open [w (io/writer outfile :append true)]
+      (.store (map->properties m) w (str "Tool Parameters - " (first (keys m)))))))

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -156,18 +156,22 @@
 (defn repo-info->param-attr-map
   [repo-info & {:keys [attrs]
                 :or   {attrs [:label :type]}}]
-  (let [zipper (->> repo-info
-                    (get-toolshed-browse-html)
-                    (xml-filename)
-                    (raw-file-xml-url repo-info)
-                    (xml-url->zipper))]
-    (into {} (map
-               (fn [attr]
-                 {attr
-                  (-> zipper
-                      (get-param-values :attrs attr)
-                      (flatten-param-values-map))})
-               attrs))))
+  (try
+    (let [zipper (->> repo-info
+                      (get-toolshed-browse-html)
+                      (xml-filename)
+                      (raw-file-xml-url repo-info)
+                      (xml-url->zipper))]
+      (into {} (map
+                 (fn [attr]
+                   {attr
+                    (-> zipper
+                        (get-param-values :attrs attr)
+                        (flatten-param-values-map))})
+                 attrs)))
+    (catch Exception e
+      (error "Could not get tool parameter attribute info for" repo-info "; Encountered error:" e)
+      nil)))
 
 (defn tool-step->param-attr-map
   [tool-step & {:keys [attrs]

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -1,7 +1,12 @@
 (ns irida-wf-ga2xml.util
   (:require [clojure.java.io :as io]
             [clojure.data.json :as json]
-            [clojure.data.xml :as xml :refer [element emit emit-str sexp-as-element indent-str]]))
+            [clojure.data.xml :as xml :refer [element emit emit-str sexp-as-element indent-str]]
+            [clojure.data.json :as json])
+  (:import (clojure.lang Keyword PersistentVector)))
+
+(def tool-id-repos-pattern (re-pattern "/repos/"))
+(def slash-pattern (re-pattern "/"))
 
 (defmacro kw-quote
   "Take one or more symbols and map-ify them.
@@ -24,6 +29,42 @@
   "Is item `x` in collection `xs`?"
   [xs x]
   (some #(= x %) xs))
+
+(defn kw->str [kw]
+  (condp = (class kw)
+    String kw
+    Keyword (->> (str kw) vec rest (apply str))
+    (throw (IllegalArgumentException. (str "Arg 'kw' is not a Clojure Keyword! class=" (class kw))))))
+
+(defn dundered?
+  "Is `x` wrapped in double underscores?"
+  [x]
+  (try
+    (boolean (re-matches #"^__.*__$" x))
+    (catch Exception _
+      false)))
+
+(defn try-parse-json [x]
+  "Try to parse `x` as JSON string."
+  (try
+    (json/read-str x)
+    (catch Exception _
+      x)))
+
+(defn recur-descend-maps
+  "Flatten a nested map with '.' delimited keys to scalar values.
+  e.g {\"a\" {\"b\" {\"c\" 1} \"d\" 2} \"e\" 3}
+  will produce the following map
+  {\"a.b.c\" 1 \"a.d\" 2 \"e\" 3}"
+  [prev-key x]
+  (if (map? x)
+    (map (fn [[k v]]
+           (let [new-key (str (kw->str prev-key) "." (kw->str k))]
+             (if (map? x)
+               (recur-descend-maps new-key v)
+               {new-key v})))
+         (remove (fn [[k _]] (dundered? k)) x))
+    {prev-key x}))
 
 (defn uuid
   "Random UUID using Java stdlib function"
@@ -58,6 +99,16 @@
 (def step-type-data_collection_input? (partial step-type? "data_collection_input"))
 (def step-type-data_input? (partial step-type? "data_input"))
 
+(defn tool-id->repo-info
+  "Get Tool Shed repo information from the Galaxy tool id if possible.
+  Check if the tool id contains '/repos/' string."
+  [tool-id]
+  (if (re-find tool-id-repos-pattern tool-id)
+    (let [[url & owner-tool-rest] (clojure.string/split tool-id tool-id-repos-pattern)
+          [owner name & _] (clojure.string/split (first owner-tool-rest) slash-pattern)]
+      (kw-quote url owner name))
+    {:url nil :owner nil :name nil}))
+
 (defn step-input-name-reference?
   "Is workflow step reference input file for a workflow that requires a reference file? (e.g. SNVPhyl)"
   [{:strs [tool_state]}]
@@ -82,10 +133,10 @@
 (defn tool-steps
   "Get \"tool\" type workflow steps order ordered by 'id'"
   [j]
-  (let [steps (get-steps j)]
-    (->> steps
-         (filter step-type-tool?)
-         (sort-by get-id))))
+  (->> j
+       (get-steps)
+       (filter step-type-tool?)
+       (sort-by get-id)))
 
 (defn reference-step
   "Get the workflow reference step as a map if it exists in workflow map `j`, nil otherwise"
@@ -115,6 +166,21 @@
         {:strs [name]} tool_state]
     name))
 
+(defn parameter-name
+  "IRIDA workflow XML tool parameter name.
+
+  Example:
+  ```clj
+  (parameter-name \"prokka\" 6 \"genus\")
+  ;;=> \"prokka-6-genus\"
+  ```"
+  [name-or-tool_id
+   step-id
+   param-name]
+  (apply str (interpose "-" [name-or-tool_id
+                             step-id
+                             param-name])))
+
 (defn has-http?
   "Does string `x` start with 'http'?"
   [x]
@@ -140,8 +206,46 @@
     (catch Exception _
       nil)))
 
-(defn vec->indented-xml
-  ""
-  [v]
+(defn tool-repo
+  "Get tool repository information for the tool at the given `step`.
+  If no 'tool_shed_repository' map exists in the `step` map, then try to get
+  the latest tool revision from the tool's Galaxy Tool Shed.
+  A warning comment is added if the latest revision is used."
+  [step]
+  (let [{:strs [tool_id
+                tool_shed_repository]} step
+        {:strs [changeset_revision owner tool_shed]} tool_shed_repository
+        url-owner-map (tool-id->repo-info tool_id)
+        tool_shed (if tool_shed
+                    tool_shed
+                    (:url url-owner-map))
+        name (:name url-owner-map)
+        owner (if owner
+                owner
+                (:owner url-owner-map))
+        url (if (has-http? tool_shed)
+              tool_shed
+              (str "https://" tool_shed))
+        revision (if changeset_revision
+                   changeset_revision
+                   ; try to get the tool revision via https then http if that fails
+                   (if-let [r (revision-from-url (galaxy-shed-url tool_id))]
+                     r
+                     (revision-from-url (galaxy-shed-url tool_id :https? false))))
+        repo-info (vec (kw-quote name owner url revision))]
+    (if name
+      (vcons
+        :repository
+        (if changeset_revision
+          repo-info
+          (conj repo-info
+                [:-comment
+                 (str "WARNING: Latest revision fetched from "
+                      (galaxy-shed-url tool_id))])))
+      nil)))
+
+(defn ^String vec->indented-xml
+  "Vector to indented XML string"
+  [^PersistentVector v]
   (indent-str
     (sexp-as-element v)))

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -36,6 +36,14 @@
     Keyword (->> (str kw) vec rest (apply str))
     (throw (IllegalArgumentException. (str "Arg 'kw' is not a Clojure Keyword! class=" (class kw))))))
 
+(defn safe-workflow-name
+  "Remove whitespace and other troublesome characters from the workflow name.
+  `wf-name` is the workflow name to make safe.
+  `repl` is the replacement character/string.
+  Returns a safe formatted workflow name."
+  [wf-name & {:keys [repl] :or {repl ""}}]
+  (clojure.string/replace wf-name #"[^\w\-]+" repl))
+
 (defn dundered?
   "Is `x` wrapped in double underscores?"
   [x]

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -1,156 +1,160 @@
 (ns irida-wf-ga2xml.core-test
-  (:require [clojure.test :refer :all]
-            [irida-wf-ga2xml.core :refer [tool-id->repo-info
-                                          tool-repo
-                                          get-step-outputs
-                                          tool-params-vec
-                                          to-wf-vec]]
-            [irida-wf-ga2xml.util :refer [vec->indented-xml
-                                          tool-steps
-                                          parse-ga]]))
+  (:require
+    [clojure.test :refer :all]
+    [irida-wf-ga2xml.util :as util]
+    [irida-wf-ga2xml.messages :as msgs]
+    [irida-wf-ga2xml.core :refer [get-step-outputs
+                                  tool-params-vec
+                                  to-wf-vec]]
+    [irida-wf-ga2xml.util :refer [vec->indented-xml
+                                  tool-steps
+                                  parse-ga]]))
 
 (def basic-wf-ga "test/data/basic-sistr-fasta-workflow.ga")
 (def sistr-ga "test/data/irida_workflow_structure.ga")
 (def snvphyl-ga "test/data/snvphyl-1.0.1-workflow.ga")
 (def masher-ga "test/data/refseq_masher.ga")
 
-(def sistr-flash-step {"tool_errors"       nil,
-                       "input_connections" {"input_type|fastq_collection" {"id" 0, "output_name" "output"}},
-                       "label"             nil,
-                       "id"                1,
-                       "tool_state"        "{\"__page__\": 0, \"min_overlap\": \"\\\"20\\\"\", \"input_type\": \"{\\\"fastq_collection\\\": null, \\\"sPaired\\\": \\\"collections\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"max_overlap\": \"\\\"300\\\"\", \"options\": \"{\\\"__current_case__\\\": 1, \\\"options_select\\\": \\\"basic\\\"}\", \"outputs\": \"{\\\"output_type\\\": \\\"Non-interleaved_fastq\\\", \\\"__current_case__\\\": 0}\"}",
-                       "position"          {"left" 447, "top" 200},
-                       "name"              "FLASH",
-                       "uuid"              "d1d70bc2-41f1-43d3-983d-c1d66f5b8470",
-                       "outputs"           [{"name" "extendedFrags", "type" "fastqsanger"}
-                                            {"name" "notCombined1", "type" "fastqsanger"}
-                                            {"name" "notCombined2", "type" "fastqsanger"}
-                                            {"name" "interNotCombined", "type" "fastqsanger"}
-                                            {"name" "readsAndPairs", "type" "tabular"}
-                                            {"name" "log_file", "type" "txt"}],
-                       "type"              "tool",
-                       "tool_version"      "1.3.0",
-                       "user_outputs"      [],
-                       "annotation"        "",
-                       "inputs"            [],
-                       "post_job_actions"  {"HideDatasetActionextendedFrags"    {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "extendedFrags"},
-                                            "HideDatasetActioninterNotCombined" {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "interNotCombined"},
-                                            "HideDatasetActionlog_file"         {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "log_file"},
-                                            "HideDatasetActionnotCombined1"     {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "notCombined1"},
-                                            "HideDatasetActionnotCombined2"     {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "notCombined2"},
-                                            "HideDatasetActionreadsAndPairs"    {"action_arguments" {},
-                                                                                 "action_type"      "HideDatasetAction",
-                                                                                 "output_name"      "readsAndPairs"},
-                                            "RenameDatasetActionlog_file"       {"action_arguments" {"newname" "flash.log"},
-                                                                                 "action_type"      "RenameDatasetAction",
-                                                                                 "output_name"      "log_file"}},
-                       "tool_id"           "irida.corefacility.ca/galaxy-shed/repos/irida/flash/FLASH/1.3.0"})
+(def sistr-flash-step
+  {"tool_errors"       nil,
+   "input_connections" {"input_type|fastq_collection" {"id" 0, "output_name" "output"}},
+   "label"             nil,
+   "id"                1,
+   "tool_state"        "{\"__page__\": 0, \"min_overlap\": \"\\\"20\\\"\", \"input_type\": \"{\\\"fastq_collection\\\": null, \\\"sPaired\\\": \\\"collections\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"max_overlap\": \"\\\"300\\\"\", \"options\": \"{\\\"__current_case__\\\": 1, \\\"options_select\\\": \\\"basic\\\"}\", \"outputs\": \"{\\\"output_type\\\": \\\"Non-interleaved_fastq\\\", \\\"__current_case__\\\": 0}\"}",
+   "position"          {"left" 447, "top" 200},
+   "name"              "FLASH",
+   "uuid"              "d1d70bc2-41f1-43d3-983d-c1d66f5b8470",
+   "outputs"           [{"name" "extendedFrags", "type" "fastqsanger"}
+                        {"name" "notCombined1", "type" "fastqsanger"}
+                        {"name" "notCombined2", "type" "fastqsanger"}
+                        {"name" "interNotCombined", "type" "fastqsanger"}
+                        {"name" "readsAndPairs", "type" "tabular"}
+                        {"name" "log_file", "type" "txt"}],
+   "type"              "tool",
+   "tool_version"      "1.3.0",
+   "user_outputs"      [],
+   "annotation"        "",
+   "inputs"            [],
+   "post_job_actions"  {"HideDatasetActionextendedFrags"    {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "extendedFrags"},
+                        "HideDatasetActioninterNotCombined" {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "interNotCombined"},
+                        "HideDatasetActionlog_file"         {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "log_file"},
+                        "HideDatasetActionnotCombined1"     {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "notCombined1"},
+                        "HideDatasetActionnotCombined2"     {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "notCombined2"},
+                        "HideDatasetActionreadsAndPairs"    {"action_arguments" {},
+                                                             "action_type"      "HideDatasetAction",
+                                                             "output_name"      "readsAndPairs"},
+                        "RenameDatasetActionlog_file"       {"action_arguments" {"newname" "flash.log"},
+                                                             "action_type"      "RenameDatasetAction",
+                                                             "output_name"      "log_file"}},
+   "tool_id"           "irida.corefacility.ca/galaxy-shed/repos/irida/flash/FLASH/1.3.0"})
 
 (def sistr-flash-step-repo-xml "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<repository>\n  <name>flash</name>\n  <owner>irida</owner>\n  <url>https://irida.corefacility.ca/galaxy-shed</url>\n  <revision>4287dd541327</revision>\n  <!--WARNING: Latest revision fetched from https://irida.corefacility.ca/galaxy-shed/repos/irida/flash-->\n</repository>\n")
 
-(def sistr-cmd-step {"tool_errors"       nil,
-                     "input_connections" {"input_fastas" {"id" 4, "output_name" "output_with_repeats"}},
-                     "label"             nil,
-                     "id"                6,
-                     "tool_state"        "{\"input_fastas\": \"null\", \"no_cgmlst\": \"\\\"False\\\"\", \"use_full_cgmlst_db\": \"\\\"True\\\"\", \"__page__\": 0, \"output_format\": \"\\\"json\\\"\", \"keep_tmp\": \"\\\"False\\\"\", \"run_mash\": \"\\\"True\\\"\", \"more_output\": \"\\\"-M\\\"\", \"__rerun_remap_job_id__\": null, \"qc\": \"\\\"True\\\"\", \"verbosity\": \"\\\"-vv\\\"\"}",
-                     "position"          {"left" 1654, "top" 490},
-                     "name"              "sistr_cmd",
-                     "uuid"              "3aa85dac-c737-44fc-8f97-8f7ed6cd798d",
-                     "outputs"           [{"name" "output_prediction_csv", "type" "csv"}
-                                          {"name" "output_prediction_json", "type" "json"}
-                                          {"name" "output_prediction_tab", "type" "tabular"}
-                                          {"name" "cgmlst_profiles", "type" "csv"}
-                                          {"name" "novel_alleles", "type" "fasta"}
-                                          {"name" "alleles_output", "type" "json"}],
-                     "type"              "tool",
-                     "tool_version"      "1.0.2",
-                     "user_outputs"      [],
-                     "annotation"        "",
-                     "inputs"            [],
-                     "post_job_actions"  {"HideDatasetActionoutput_prediction_csv"    {"action_arguments" {},
-                                                                                       "action_type"      "HideDatasetAction",
-                                                                                       "output_name"      "output_prediction_csv"},
-                                          "HideDatasetActionoutput_prediction_tab"    {"action_arguments" {},
-                                                                                       "action_type"      "HideDatasetAction",
-                                                                                       "output_name"      "output_prediction_tab"},
-                                          "RenameDatasetActionalleles_output"         {"action_arguments" {"newname" "sistr-alleles-out.json"},
-                                                                                       "action_type"      "RenameDatasetAction",
-                                                                                       "output_name"      "alleles_output"},
-                                          "RenameDatasetActioncgmlst_profiles"        {"action_arguments" {"newname" "sistr-cgmlst-profiles.csv"},
-                                                                                       "action_type"      "RenameDatasetAction",
-                                                                                       "output_name"      "cgmlst_profiles"},
-                                          "RenameDatasetActionnovel_alleles"          {"action_arguments" {"newname" "sistr-novel-alleles.fasta"},
-                                                                                       "action_type"      "RenameDatasetAction",
-                                                                                       "output_name"      "novel_alleles"},
-                                          "RenameDatasetActionoutput_prediction_json" {"action_arguments" {"newname" "sistr-predictions.json"},
-                                                                                       "action_type"      "RenameDatasetAction",
-                                                                                       "output_name"      "output_prediction_json"}},
-                     "tool_id"           "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2"})
+(def sistr-cmd-step
+  {"tool_errors"       nil,
+   "input_connections" {"input_fastas" {"id" 4, "output_name" "output_with_repeats"}},
+   "label"             nil,
+   "id"                6,
+   "tool_state"        "{\"input_fastas\": \"null\", \"no_cgmlst\": \"\\\"False\\\"\", \"use_full_cgmlst_db\": \"\\\"True\\\"\", \"__page__\": 0, \"output_format\": \"\\\"json\\\"\", \"keep_tmp\": \"\\\"False\\\"\", \"run_mash\": \"\\\"True\\\"\", \"more_output\": \"\\\"-M\\\"\", \"__rerun_remap_job_id__\": null, \"qc\": \"\\\"True\\\"\", \"verbosity\": \"\\\"-vv\\\"\"}",
+   "position"          {"left" 1654, "top" 490},
+   "name"              "sistr_cmd",
+   "uuid"              "3aa85dac-c737-44fc-8f97-8f7ed6cd798d",
+   "outputs"           [{"name" "output_prediction_csv", "type" "csv"}
+                        {"name" "output_prediction_json", "type" "json"}
+                        {"name" "output_prediction_tab", "type" "tabular"}
+                        {"name" "cgmlst_profiles", "type" "csv"}
+                        {"name" "novel_alleles", "type" "fasta"}
+                        {"name" "alleles_output", "type" "json"}],
+   "type"              "tool",
+   "tool_version"      "1.0.2",
+   "user_outputs"      [],
+   "annotation"        "",
+   "inputs"            [],
+   "post_job_actions"  {"HideDatasetActionoutput_prediction_csv"    {"action_arguments" {},
+                                                                     "action_type"      "HideDatasetAction",
+                                                                     "output_name"      "output_prediction_csv"},
+                        "HideDatasetActionoutput_prediction_tab"    {"action_arguments" {},
+                                                                     "action_type"      "HideDatasetAction",
+                                                                     "output_name"      "output_prediction_tab"},
+                        "RenameDatasetActionalleles_output"         {"action_arguments" {"newname" "sistr-alleles-out.json"},
+                                                                     "action_type"      "RenameDatasetAction",
+                                                                     "output_name"      "alleles_output"},
+                        "RenameDatasetActioncgmlst_profiles"        {"action_arguments" {"newname" "sistr-cgmlst-profiles.csv"},
+                                                                     "action_type"      "RenameDatasetAction",
+                                                                     "output_name"      "cgmlst_profiles"},
+                        "RenameDatasetActionnovel_alleles"          {"action_arguments" {"newname" "sistr-novel-alleles.fasta"},
+                                                                     "action_type"      "RenameDatasetAction",
+                                                                     "output_name"      "novel_alleles"},
+                        "RenameDatasetActionoutput_prediction_json" {"action_arguments" {"newname" "sistr-predictions.json"},
+                                                                     "action_type"      "RenameDatasetAction",
+                                                                     "output_name"      "output_prediction_json"}},
+   "tool_id"           "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2"})
 
-(def sistr-cmd-step-new {"tool_errors"          nil,
-                         "workflow_outputs"     [{"label"       nil,
-                                                  "output_name" "alleles_output",
-                                                  "uuid"        "93f63a3b-ef41-4cd0-b378-c7ceaf624959"}
-                                                 {"label"       nil,
-                                                  "output_name" "output_prediction_json",
-                                                  "uuid"        "484986a3-68cb-4e75-afaa-cb7cd196a85e"}
-                                                 {"label"       nil,
-                                                  "output_name" "novel_alleles",
-                                                  "uuid"        "a6a77064-95bf-4e35-bf27-4e6434d3fd20"}
-                                                 {"label"       nil,
-                                                  "output_name" "cgmlst_profiles",
-                                                  "uuid"        "9cbd838e-8331-4969-9824-6b5c16a8e279"}],
-                         "input_connections"    {"input_fastas" {"id" 0, "output_name" "output"}},
-                         "label"                nil,
-                         "id"                   1,
-                         "tool_state"           "{\"input_fastas\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_cgmlst\": \"\\\"false\\\"\", \"use_full_cgmlst_db\": \"\\\"false\\\"\", \"__page__\": 0, \"output_format\": \"\\\"json\\\"\", \"keep_tmp\": \"\\\"false\\\"\", \"run_mash\": \"\\\"true\\\"\", \"more_output\": \"\\\"-MM\\\"\", \"__rerun_remap_job_id__\": null, \"qc\": \"\\\"true\\\"\", \"verbosity\": \"\\\"-vv\\\"\"}",
-                         "position"             {"left" 428.015625, "top" 199.9921875},
-                         "name"                 "sistr_cmd",
-                         "uuid"                 "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9",
-                         "outputs"              [{"name" "output_prediction_csv", "type" "csv"}
-                                                 {"name" "output_prediction_json", "type" "json"}
-                                                 {"name" "output_prediction_tab", "type" "tabular"}
-                                                 {"name" "cgmlst_profiles", "type" "csv"}
-                                                 {"name" "novel_alleles", "type" "fasta"}
-                                                 {"name" "alleles_output", "type" "json"}],
-                         "tool_shed_repository" {"changeset_revision" "5c8ff92e38a9",
-                                                 "name"               "sistr_cmd",
-                                                 "owner"              "nml",
-                                                 "tool_shed"          "toolshed.g2.bx.psu.edu"},
-                         "type"                 "tool",
-                         "tool_version"         "1.0.2",
-                         "annotation"           "",
-                         "inputs"               [{"description" "runtime parameter for tool sistr_cmd", "name" "input_fastas"}],
-                         "post_job_actions"     {"HideDatasetActionoutput_prediction_csv"    {"action_arguments" {},
-                                                                                              "action_type"      "HideDatasetAction",
-                                                                                              "output_name"      "output_prediction_csv"},
-                                                 "HideDatasetActionoutput_prediction_tab"    {"action_arguments" {},
-                                                                                              "action_type"      "HideDatasetAction",
-                                                                                              "output_name"      "output_prediction_tab"},
-                                                 "RenameDatasetActionalleles_output"         {"action_arguments" {"newname" "sistr-alleles.json"},
-                                                                                              "action_type"      "RenameDatasetAction",
-                                                                                              "output_name"      "alleles_output"},
-                                                 "RenameDatasetActioncgmlst_profiles"        {"action_arguments" {"newname" "sistr-cgmlst-profiles.csv"},
-                                                                                              "action_type"      "RenameDatasetAction",
-                                                                                              "output_name"      "cgmlst_profiles"},
-                                                 "RenameDatasetActionnovel_alleles"          {"action_arguments" {"newname" "sistr-novel-alleles.fasta"},
-                                                                                              "action_type"      "RenameDatasetAction",
-                                                                                              "output_name"      "novel_alleles"},
-                                                 "RenameDatasetActionoutput_prediction_json" {"action_arguments" {"newname" "sistr-predictions.json"},
-                                                                                              "action_type"      "RenameDatasetAction",
-                                                                                              "output_name"      "output_prediction_json"}},
-                         "content_id"           "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2",
-                         "tool_id"              "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2"})
+(def sistr-cmd-step-new
+  {"tool_errors"          nil,
+   "workflow_outputs"     [{"label"       nil,
+                            "output_name" "alleles_output",
+                            "uuid"        "93f63a3b-ef41-4cd0-b378-c7ceaf624959"}
+                           {"label"       nil,
+                            "output_name" "output_prediction_json",
+                            "uuid"        "484986a3-68cb-4e75-afaa-cb7cd196a85e"}
+                           {"label"       nil,
+                            "output_name" "novel_alleles",
+                            "uuid"        "a6a77064-95bf-4e35-bf27-4e6434d3fd20"}
+                           {"label"       nil,
+                            "output_name" "cgmlst_profiles",
+                            "uuid"        "9cbd838e-8331-4969-9824-6b5c16a8e279"}],
+   "input_connections"    {"input_fastas" {"id" 0, "output_name" "output"}},
+   "label"                nil,
+   "id"                   1,
+   "tool_state"           "{\"input_fastas\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_cgmlst\": \"\\\"false\\\"\", \"use_full_cgmlst_db\": \"\\\"false\\\"\", \"__page__\": 0, \"output_format\": \"\\\"json\\\"\", \"keep_tmp\": \"\\\"false\\\"\", \"run_mash\": \"\\\"true\\\"\", \"more_output\": \"\\\"-MM\\\"\", \"__rerun_remap_job_id__\": null, \"qc\": \"\\\"true\\\"\", \"verbosity\": \"\\\"-vv\\\"\"}",
+   "position"             {"left" 428.015625, "top" 199.9921875},
+   "name"                 "sistr_cmd",
+   "uuid"                 "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9",
+   "outputs"              [{"name" "output_prediction_csv", "type" "csv"}
+                           {"name" "output_prediction_json", "type" "json"}
+                           {"name" "output_prediction_tab", "type" "tabular"}
+                           {"name" "cgmlst_profiles", "type" "csv"}
+                           {"name" "novel_alleles", "type" "fasta"}
+                           {"name" "alleles_output", "type" "json"}],
+   "tool_shed_repository" {"changeset_revision" "5c8ff92e38a9",
+                           "name"               "sistr_cmd",
+                           "owner"              "nml",
+                           "tool_shed"          "toolshed.g2.bx.psu.edu"},
+   "type"                 "tool",
+   "tool_version"         "1.0.2",
+   "annotation"           "",
+   "inputs"               [{"description" "runtime parameter for tool sistr_cmd", "name" "input_fastas"}],
+   "post_job_actions"     {"HideDatasetActionoutput_prediction_csv"    {"action_arguments" {},
+                                                                        "action_type"      "HideDatasetAction",
+                                                                        "output_name"      "output_prediction_csv"},
+                           "HideDatasetActionoutput_prediction_tab"    {"action_arguments" {},
+                                                                        "action_type"      "HideDatasetAction",
+                                                                        "output_name"      "output_prediction_tab"},
+                           "RenameDatasetActionalleles_output"         {"action_arguments" {"newname" "sistr-alleles.json"},
+                                                                        "action_type"      "RenameDatasetAction",
+                                                                        "output_name"      "alleles_output"},
+                           "RenameDatasetActioncgmlst_profiles"        {"action_arguments" {"newname" "sistr-cgmlst-profiles.csv"},
+                                                                        "action_type"      "RenameDatasetAction",
+                                                                        "output_name"      "cgmlst_profiles"},
+                           "RenameDatasetActionnovel_alleles"          {"action_arguments" {"newname" "sistr-novel-alleles.fasta"},
+                                                                        "action_type"      "RenameDatasetAction",
+                                                                        "output_name"      "novel_alleles"},
+                           "RenameDatasetActionoutput_prediction_json" {"action_arguments" {"newname" "sistr-predictions.json"},
+                                                                        "action_type"      "RenameDatasetAction",
+                                                                        "output_name"      "output_prediction_json"}},
+   "content_id"           "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2",
+   "tool_id"              "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2"})
 
 (def sistr-cmd-step-new-tool-params
   [[:parameter
@@ -275,7 +279,7 @@
 
 (deftest tool-shed-repo-info-from-tool-id
   (testing "Parsing of tool shed url, owner, tool name from tool id"
-    (is (= (tool-id->repo-info "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2")
+    (is (= (util/tool-id->repo-info "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2")
            {:url "toolshed.g2.bx.psu.edu", :owner "nml", :name "sistr_cmd"}))))
 
 (deftest outputs-from-workflow-step
@@ -291,52 +295,54 @@
 
 (deftest parse-tool-shed-repo-info
   (testing "Parsing of Galaxy workflow step for tool toolshed repository information"
-    (is (= (tool-repo sistr-cmd-step-new)
+    (is (= (util/tool-repo sistr-cmd-step-new)
            [:repository [:name "sistr_cmd"] [:owner "nml"] [:url "https://toolshed.g2.bx.psu.edu"] [:revision "5c8ff92e38a9"]]))
-    (is (= (tool-repo sistr-cmd-step)
+    (is (= (util/tool-repo sistr-cmd-step)
            [:repository
             [:name "sistr_cmd"]
             [:owner "nml"]
             [:url "https://toolshed.g2.bx.psu.edu"]
             [:revision "5c8ff92e38a9"]
             [:-comment "WARNING: Latest revision fetched from https://toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd"]]))
-    (is (nil? (tool-repo snvphyl-cat-step)))))
+    (is (nil? (util/tool-repo snvphyl-cat-step)))))
 
 (deftest parse-tool-params
   (testing "Parsing of sistr_cmd tool parameters."
-    (is (= (tool-params-vec sistr-cmd-step-new)
+    (is (= (:xml-vec (tool-params-vec sistr-cmd-step-new :get-param-labels? false))
            sistr-cmd-step-new-tool-params)))
   (testing "Parsing of SNVPhyl FreeBayes step deeply nested parameters."
-    (is (= (tool-params-vec snvphyl-freebayes-step)
+    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false))
            snvphyl-freebayes-step-tool-params))))
 
 (deftest workflow-to-vector
   (testing "Parsing of basic sistr_cmd workflow with FASTA input"
-    (let [wf (to-wf-vec basic-wf-ga)]
+    (let [wf (:xml-vec (to-wf-vec basic-wf-ga :output-messages? false))]
       (is (= (first wf)
              :iridaWorkflow))
       (is (= (count wf)
              9))))
   (testing "Parsing of basic sistr_cmd workflow with FASTQ input"
-    (let [wf (to-wf-vec sistr-ga)]
+    (let [wf (:xml-vec (to-wf-vec sistr-ga :output-messages? false))]
       (is (= (first wf)
              :iridaWorkflow))
       (is (= (count wf)
              9))))
   (testing "Parsing of SNVPhyl workflow"
-    (let [wf (to-wf-vec snvphyl-ga
-                        :single-sample? false
-                        :wf-version "1.0.1"
-                        :analysis-type "phylogenomics")]
+    (let [wf (:xml-vec (to-wf-vec snvphyl-ga
+                                  :single-sample? false
+                                  :wf-version "1.0.1"
+                                  :analysis-type "phylogenomics"
+                                  :output-messages? false))]
       (is (= (first wf)
              :iridaWorkflow))
       (is (= (count wf)
              9))))
   (testing "Parsing of refseq_masher workflow"
-    (let [wf (to-wf-vec masher-ga
-                        :single-sample? true
-                        :wf-version "0.1.0"
-                        :analysis-type "refseq_masher")]
+    (let [wf (:xml-vec (to-wf-vec masher-ga
+                                  :single-sample? true
+                                  :wf-version "0.1.0"
+                                  :analysis-type "refseq_masher"
+                                  :output-messages? false))]
       (is (= (first wf)
              :iridaWorkflow))
       (is (= (count wf)
@@ -350,6 +356,6 @@
                [:revision "26df66c32861"]]])))))
 
 (deftest vec-to-xml
-  (let [flash-shed-info (tool-repo sistr-flash-step)]
+  (let [flash-shed-info (util/tool-repo sistr-flash-step)]
     (is (= (vec->indented-xml flash-shed-info)
            sistr-flash-step-repo-xml))))

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -5,6 +5,7 @@
     [irida-wf-ga2xml.messages :as msgs]
     [irida-wf-ga2xml.core :refer [get-step-outputs
                                   tool-params-vec
+                                  tool-params-map
                                   to-wf-vec]]
     [irida-wf-ga2xml.util :refer [vec->indented-xml
                                   tool-steps
@@ -285,13 +286,15 @@
 (deftest outputs-from-workflow-step
   (testing "Getting outputs for FLASH step in SISTR from reads workflow"
     (is (= (vec (get-step-outputs sistr-flash-step))
+           [[:output {:name "flash.log", :fileName "flash.log"}]]))
+    (is (= (vec (get-step-outputs sistr-flash-step :remove-file-ext? true))
            [[:output {:name "flash", :fileName "flash.log"}]])))
   (testing "Getting outputs for sistr_cmd step"
     (is (= (vec (get-step-outputs sistr-cmd-step))
-           [[:output {:name "sistr-alleles-out", :fileName "sistr-alleles-out.json"}]
-            [:output {:name "sistr-cgmlst-profiles", :fileName "sistr-cgmlst-profiles.csv"}]
-            [:output {:name "sistr-novel-alleles", :fileName "sistr-novel-alleles.fasta"}]
-            [:output {:name "sistr-predictions", :fileName "sistr-predictions.json"}]]))))
+           [[:output {:name "sistr-alleles-out.json", :fileName "sistr-alleles-out.json"}]
+            [:output {:name "sistr-cgmlst-profiles.csv", :fileName "sistr-cgmlst-profiles.csv"}]
+            [:output {:name "sistr-novel-alleles.fasta", :fileName "sistr-novel-alleles.fasta"}]
+            [:output {:name "sistr-predictions.json", :fileName "sistr-predictions.json"}]]))))
 
 (deftest parse-tool-shed-repo-info
   (testing "Parsing of Galaxy workflow step for tool toolshed repository information"

--- a/test/irida_wf_ga2xml/messages_test.clj
+++ b/test/irida_wf_ga2xml/messages_test.clj
@@ -21,110 +21,138 @@
    :revision "4654c51dae72"
    :url      "https://toolshed.g2.bx.psu.edu"})
 
-(def prokka-expected-param-label-map
-  {"genus"                      "Genus name (--genus)",
-   "species"                    "Species name (--species)",
-   "gffver"                     "GFF version (--gffver)",
-   "centre"                     "Sequencing centre ID (--centre)",
-   "kingdom.kingdom_select"     "Kingdom (--kingdom)",
-   "compliant.compliant_select" "Force GenBank/ENA/DDJB compliance (--compliant)",
-   "increment"                  "Locus tag counter increment (--increment)",
-   "evalue"                     "Similarity e-value cut-off",
-   "locustag"                   "Locus tag prefix (--locustag)",
-   "outputs"                    "Additional outputs",
-   "kingdom.gcode"              "Genetic code (transl_table)",
-   "fast"                       "Fast mode (--fast)",
-   "usegenus"                   "Use genus-specific BLAST database (--usegenus)",
-   "input"                      "Contigs to annotate",
-   "plasmid"                    "Plasmid name or identifier (--plasmid)",
-   "notrna"                     "Don't run tRNA search with Aragorn",
-   "compliant.mincontig"        "Minimum contig size (--mincontiglen)",
-   "proteins"                   "Optional FASTA file of trusted proteins to first annotate from (--proteins)",
-   "norrna"                     "Don't run rRNA search with Barrnap",
-   "metagenome"                 "Improve gene predictions for highly fragmented genomes (--metagenome)",
-   "compliant.addgenes"         "Add 'gene' features for each 'CDS' feature (--addgenes)",
-   "strain"                     "Strain name (--strain)",
-   "rfam"                       "Enable searching for ncRNAs with Infernal+Rfam (SLOW!) (--rfam)"})
+(def prokka-expected-param-attrs
+  {:label {"genus"                      "Genus name (--genus)",
+           "species"                    "Species name (--species)",
+           "gffver"                     "GFF version (--gffver)",
+           "centre"                     "Sequencing centre ID (--centre)",
+           "kingdom.kingdom_select"     "Kingdom (--kingdom)",
+           "compliant.compliant_select" "Force GenBank/ENA/DDJB compliance (--compliant)",
+           "increment"                  "Locus tag counter increment (--increment)",
+           "evalue"                     "Similarity e-value cut-off",
+           "locustag"                   "Locus tag prefix (--locustag)",
+           "outputs"                    "Additional outputs",
+           "kingdom.gcode"              "Genetic code (transl_table)",
+           "fast"                       "Fast mode (--fast)",
+           "usegenus"                   "Use genus-specific BLAST database (--usegenus)",
+           "input"                      "Contigs to annotate",
+           "plasmid"                    "Plasmid name or identifier (--plasmid)",
+           "notrna"                     "Don't run tRNA search with Aragorn",
+           "compliant.mincontig"        "Minimum contig size (--mincontiglen)",
+           "proteins"                   "Optional FASTA file of trusted proteins to first annotate from (--proteins)",
+           "norrna"                     "Don't run rRNA search with Barrnap",
+           "metagenome"                 "Improve gene predictions for highly fragmented genomes (--metagenome)",
+           "compliant.addgenes"         "Add 'gene' features for each 'CDS' feature (--addgenes)",
+           "strain"                     "Strain name (--strain)",
+           "rfam"                       "Enable searching for ncRNAs with Infernal+Rfam (SLOW!) (--rfam)"},
+   :type  {"genus"                      "text",
+           "species"                    "text",
+           "gffver"                     "select",
+           "centre"                     "text",
+           "kingdom.kingdom_select"     "select",
+           "compliant.compliant_select" "select",
+           "increment"                  "integer",
+           "evalue"                     "float",
+           "locustag"                   "text",
+           "outputs"                    "select",
+           "kingdom.gcode"              "integer",
+           "fast"                       "boolean",
+           "usegenus"                   "boolean",
+           "input"                      "data",
+           "plasmid"                    "text",
+           "notrna"                     "boolean",
+           "compliant.mincontig"        "integer",
+           "proteins"                   "data",
+           "norrna"                     "boolean",
+           "metagenome"                 "boolean",
+           "compliant.addgenes"         "boolean",
+           "strain"                     "text",
+           "rfam"                       "boolean"}})
 
+(def flash-expected-param-attrs
+  {:label {"input_type.sPaired"           "Single Pair or Collection",
+           "min_overlap"                  "Minimum overlap",
+           "options.options_select"       "Options Type",
+           "options.cap_mismatch_quals"   "Cap mismatch quality scores",
+           "outputs.output_type"          "Output type",
+           "options.fragment_length"      "Fragment length",
+           "input_type.pInput2"           "Reverse FASTQ file",
+           "options.max_mismatch_density" "Maximum mismatch density",
+           "input_type.fastq_collection"  "Paired-end Fastq collection",
+           "options.quiet"                "Do not print informational messages",
+           "options.read_length"          "Average read length",
+           "options.fragment_stdev"       "Fragment length standard deviation",
+           "input_type.pInput1"           "Forward FASTQ file",
+           "max_overlap"                  "Maximum overlap",
+           "options.phred_offset"         "Phred-offset"},
+   :type  {"input_type.sPaired"           "select",
+           "min_overlap"                  "integer",
+           "options.options_select"       "select",
+           "options.cap_mismatch_quals"   "boolean",
+           "outputs.output_type"          "select",
+           "options.fragment_length"      "integer",
+           "input_type.pInput2"           "data",
+           "options.max_mismatch_density" "float",
+           "input_type.fastq_collection"  "data_collection",
+           "options.quiet"                "boolean",
+           "options.read_length"          "integer",
+           "options.fragment_stdev"       "integer",
+           "input_type.pInput1"           "data",
+           "max_overlap"                  "integer",
+           "options.phred_offset"         "select"}})
 
-(def prokka-expected-param-type-map
-  {"genus"                      "text",
-   "species"                    "text",
-   "gffver"                     "select",
-   "centre"                     "text",
-   "kingdom.kingdom_select"     "select",
-   "compliant.compliant_select" "select",
-   "increment"                  "integer",
-   "evalue"                     "float",
-   "locustag"                   "text",
-   "outputs"                    "select",
-   "kingdom.gcode"              "integer",
-   "fast"                       "boolean",
-   "usegenus"                   "boolean",
-   "input"                      "data",
-   "plasmid"                    "text",
-   "notrna"                     "boolean",
-   "compliant.mincontig"        "integer",
-   "proteins"                   "data",
-   "norrna"                     "boolean",
-   "metagenome"                 "boolean",
-   "compliant.addgenes"         "boolean",
-   "strain"                     "text",
-   "rfam"                       "boolean"})
-
-
-
-(def flash-expected-param-label-map
-  {"input_type.sPaired"           "Single Pair or Collection",
-   "min_overlap"                  "Minimum overlap",
-   "options.options_select"       "Options Type",
-   "options.cap_mismatch_quals"   "Cap mismatch quality scores",
-   "outputs.output_type"          "Output type",
-   "options.fragment_length"      "Fragment length",
-   "input_type.pInput2"           "Reverse FASTQ file",
-   "options.max_mismatch_density" "Maximum mismatch density",
-   "input_type.fastq_collection"  "Paired-end Fastq collection",
-   "options.quiet"                "Do not print informational messages",
-   "options.read_length"          "Average read length",
-   "options.fragment_stdev"       "Fragment length standard deviation",
-   "input_type.pInput1"           "Forward FASTQ file",
-   "max_overlap"                  "Maximum overlap",
-   "options.phred_offset"         "Phred-offset"})
-
-(def biohansel-expected-param-label-map
-  {"input.reverse"                  "Reverse FASTQ file",
-   "qc_vals.max_missing_tiles"      "QC: Decimal Proportion of max allowed missing tiles",
-   "kmer_vals.kmer_max"             "Max k-mer frequency/coverage",
-   "type_of_scheme.scheme_type"     "Specify scheme to use. (Heidelberg is default)",
-   "input.paired_collection"        "Paired-end FASTQ collection",
-   "input.single"                   "Single-end FASTQ file",
-   "qc_vals.max_intermediate_tiles" "QC: Decimal Proportion of max allowed missing tiles for an intermediate subtype",
-   "qc_vals.low_coverage_warning"   "QC: Overall tile coverage below this value will trigger a low coverage warning",
-   "dev_args.use_json"              "Output JSON results",
-   "input.fasta"                    "FASTA file",
-   "qc_vals.min_ambiguous_tiles"    "QC: Min number of tiles missing for Ambiguous Result",
-   "input.type"                     "Sequence input type",
-   "qc_vals.low_cov_depth_freq"     "QC: Frequency below this coverage are considered low coverage",
-   "type_of_scheme.scheme_input"    "Scheme Input",
-   "input.forward"                  "Forward FASTQ file",
-   "kmer_vals.kmer_min"             "Min k-mer frequency/coverage"})
+(def biohansel-expected-param-attrs
+  {:label {"input.reverse"                  "Reverse FASTQ file",
+           "qc_vals.max_missing_tiles"      "QC: Decimal Proportion of max allowed missing tiles",
+           "kmer_vals.kmer_max"             "Max k-mer frequency/coverage",
+           "type_of_scheme.scheme_type"     "Specify scheme to use. (Heidelberg is default)",
+           "input.paired_collection"        "Paired-end FASTQ collection",
+           "input.single"                   "Single-end FASTQ file",
+           "qc_vals.max_intermediate_tiles" "QC: Decimal Proportion of max allowed missing tiles for an intermediate subtype",
+           "qc_vals.low_coverage_warning"   "QC: Overall tile coverage below this value will trigger a low coverage warning",
+           "dev_args.use_json"              "Output JSON results",
+           "input.fasta"                    "FASTA file",
+           "qc_vals.min_ambiguous_tiles"    "QC: Min number of tiles missing for Ambiguous Result",
+           "input.type"                     "Sequence input type",
+           "qc_vals.low_cov_depth_freq"     "QC: Frequency below this coverage are considered low coverage",
+           "type_of_scheme.scheme_input"    "Scheme Input",
+           "input.forward"                  "Forward FASTQ file",
+           "kmer_vals.kmer_min"             "Min k-mer frequency/coverage"},
+   :type  {"input.reverse"                  "data",
+           "qc_vals.max_missing_tiles"      "float",
+           "kmer_vals.kmer_max"             "integer",
+           "type_of_scheme.scheme_type"     "select",
+           "input.paired_collection"        "data_collection",
+           "input.single"                   "data",
+           "qc_vals.max_intermediate_tiles" "float",
+           "qc_vals.low_coverage_warning"   "integer",
+           "dev_args.use_json"              "boolean",
+           "input.fasta"                    "data",
+           "qc_vals.min_ambiguous_tiles"    "integer",
+           "input.type"                     "select",
+           "qc_vals.low_cov_depth_freq"     "integer",
+           "type_of_scheme.scheme_input"    "data",
+           "input.forward"                  "data",
+           "kmer_vals.kmer_min"             "integer"}})
 
 (deftest param-values-map-from-tool-repo-info
-  (is (= prokka-expected-param-label-map
+  (is (= prokka-expected-param-attrs
          (repo-info->param-attr-map prokka-repo-info)))
-  (is (= prokka-expected-param-type-map
-         (repo-info->param-attr-map prokka-repo-info :get-attr :type)))
-  (is (= flash-expected-param-label-map
+  (is (= flash-expected-param-attrs
          (repo-info->param-attr-map flash-repo-info)))
-  (is (= biohansel-expected-param-label-map
+  (is (= biohansel-expected-param-attrs
          (repo-info->param-attr-map biohansel-repo-info))))
 
 (deftest build-messages-map
   (let [default-msgs (default-workflow-messages "biohansel" "biohansel" "Hansel?")]
-    (is (= {"workflow.biohansel.title" "biohansel Pipeline",
-            "workflow.biohansel.description" "Hansel?",
-            "pipeline.title.biohansel" "Pipelines - biohansel",
-            "pipeline.h1.biohansel" "biohansel Pipeline",
+    (is (= {"workflow.biohansel.title"                  "biohansel Pipeline",
+            "workflow.biohansel.description"            "Hansel?",
+            "pipeline.title.biohansel"                  "Pipelines - biohansel",
+            "pipeline.h1.biohansel"                     "biohansel Pipeline",
             "pipeline.parameters.modal-title.biohansel" "biohansel Pipeline Parameters"}
-           default-msgs))
-    ))
+           default-msgs))))
+
+(deftest tool-step-info-from-messages-key
+  (let [some-msg-key "pipeline.parameters.biohansel.bio_hansel-1-type_of_scheme.scheme_type"]
+    (is (msg-key->tool-step-number-map some-msg-key)
+        {:tool "bio_hansel", :step-number "1"})))

--- a/test/irida_wf_ga2xml/messages_test.clj
+++ b/test/irida_wf_ga2xml/messages_test.clj
@@ -1,0 +1,130 @@
+(ns irida-wf-ga2xml.messages_test
+  (:require
+    [clojure.test :refer :all]
+    [irida-wf-ga2xml.messages :refer :all]))
+
+(def prokka-repo-info
+  {:name     "prokka"
+   :owner    "crs4"
+   :revision "eaee459f3d69"
+   :url      "https://toolshed.g2.bx.psu.edu"})
+
+(def flash-repo-info
+  {:name     "flash"
+   :owner    "irida"
+   :revision "4287dd541327"
+   :url      "https://irida.corefacility.ca/galaxy-shed"})
+
+(def biohansel-repo-info
+  {:owner    "nml"
+   :name     "bio_hansel"
+   :revision "4654c51dae72"
+   :url      "https://toolshed.g2.bx.psu.edu"})
+
+(def prokka-expected-param-label-map
+  {"genus"                      "Genus name (--genus)",
+   "species"                    "Species name (--species)",
+   "gffver"                     "GFF version (--gffver)",
+   "centre"                     "Sequencing centre ID (--centre)",
+   "kingdom.kingdom_select"     "Kingdom (--kingdom)",
+   "compliant.compliant_select" "Force GenBank/ENA/DDJB compliance (--compliant)",
+   "increment"                  "Locus tag counter increment (--increment)",
+   "evalue"                     "Similarity e-value cut-off",
+   "locustag"                   "Locus tag prefix (--locustag)",
+   "outputs"                    "Additional outputs",
+   "kingdom.gcode"              "Genetic code (transl_table)",
+   "fast"                       "Fast mode (--fast)",
+   "usegenus"                   "Use genus-specific BLAST database (--usegenus)",
+   "input"                      "Contigs to annotate",
+   "plasmid"                    "Plasmid name or identifier (--plasmid)",
+   "notrna"                     "Don't run tRNA search with Aragorn",
+   "compliant.mincontig"        "Minimum contig size (--mincontiglen)",
+   "proteins"                   "Optional FASTA file of trusted proteins to first annotate from (--proteins)",
+   "norrna"                     "Don't run rRNA search with Barrnap",
+   "metagenome"                 "Improve gene predictions for highly fragmented genomes (--metagenome)",
+   "compliant.addgenes"         "Add 'gene' features for each 'CDS' feature (--addgenes)",
+   "strain"                     "Strain name (--strain)",
+   "rfam"                       "Enable searching for ncRNAs with Infernal+Rfam (SLOW!) (--rfam)"})
+
+
+(def prokka-expected-param-type-map
+  {"genus"                      "text",
+   "species"                    "text",
+   "gffver"                     "select",
+   "centre"                     "text",
+   "kingdom.kingdom_select"     "select",
+   "compliant.compliant_select" "select",
+   "increment"                  "integer",
+   "evalue"                     "float",
+   "locustag"                   "text",
+   "outputs"                    "select",
+   "kingdom.gcode"              "integer",
+   "fast"                       "boolean",
+   "usegenus"                   "boolean",
+   "input"                      "data",
+   "plasmid"                    "text",
+   "notrna"                     "boolean",
+   "compliant.mincontig"        "integer",
+   "proteins"                   "data",
+   "norrna"                     "boolean",
+   "metagenome"                 "boolean",
+   "compliant.addgenes"         "boolean",
+   "strain"                     "text",
+   "rfam"                       "boolean"})
+
+
+
+(def flash-expected-param-label-map
+  {"input_type.sPaired"           "Single Pair or Collection",
+   "min_overlap"                  "Minimum overlap",
+   "options.options_select"       "Options Type",
+   "options.cap_mismatch_quals"   "Cap mismatch quality scores",
+   "outputs.output_type"          "Output type",
+   "options.fragment_length"      "Fragment length",
+   "input_type.pInput2"           "Reverse FASTQ file",
+   "options.max_mismatch_density" "Maximum mismatch density",
+   "input_type.fastq_collection"  "Paired-end Fastq collection",
+   "options.quiet"                "Do not print informational messages",
+   "options.read_length"          "Average read length",
+   "options.fragment_stdev"       "Fragment length standard deviation",
+   "input_type.pInput1"           "Forward FASTQ file",
+   "max_overlap"                  "Maximum overlap",
+   "options.phred_offset"         "Phred-offset"})
+
+(def biohansel-expected-param-label-map
+  {"input.reverse"                  "Reverse FASTQ file",
+   "qc_vals.max_missing_tiles"      "QC: Decimal Proportion of max allowed missing tiles",
+   "kmer_vals.kmer_max"             "Max k-mer frequency/coverage",
+   "type_of_scheme.scheme_type"     "Specify scheme to use. (Heidelberg is default)",
+   "input.paired_collection"        "Paired-end FASTQ collection",
+   "input.single"                   "Single-end FASTQ file",
+   "qc_vals.max_intermediate_tiles" "QC: Decimal Proportion of max allowed missing tiles for an intermediate subtype",
+   "qc_vals.low_coverage_warning"   "QC: Overall tile coverage below this value will trigger a low coverage warning",
+   "dev_args.use_json"              "Output JSON results",
+   "input.fasta"                    "FASTA file",
+   "qc_vals.min_ambiguous_tiles"    "QC: Min number of tiles missing for Ambiguous Result",
+   "input.type"                     "Sequence input type",
+   "qc_vals.low_cov_depth_freq"     "QC: Frequency below this coverage are considered low coverage",
+   "type_of_scheme.scheme_input"    "Scheme Input",
+   "input.forward"                  "Forward FASTQ file",
+   "kmer_vals.kmer_min"             "Min k-mer frequency/coverage"})
+
+(deftest param-values-map-from-tool-repo-info
+  (is (= prokka-expected-param-label-map
+         (repo-info->param-attr-map prokka-repo-info)))
+  (is (= prokka-expected-param-type-map
+         (repo-info->param-attr-map prokka-repo-info :get-attr :type)))
+  (is (= flash-expected-param-label-map
+         (repo-info->param-attr-map flash-repo-info)))
+  (is (= biohansel-expected-param-label-map
+         (repo-info->param-attr-map biohansel-repo-info))))
+
+(deftest build-messages-map
+  (let [default-msgs (default-workflow-messages "biohansel" "biohansel" "Hansel?")]
+    (is (= {"workflow.biohansel.title" "biohansel Pipeline",
+            "workflow.biohansel.description" "Hansel?",
+            "pipeline.title.biohansel" "Pipelines - biohansel",
+            "pipeline.h1.biohansel" "biohansel Pipeline",
+            "pipeline.parameters.modal-title.biohansel" "biohansel Pipeline Parameters"}
+           default-msgs))
+    ))

--- a/test/irida_wf_ga2xml/util_test.clj
+++ b/test/irida_wf_ga2xml/util_test.clj
@@ -17,6 +17,12 @@
             :cool      "beans"
             :awesome   1}))))
 
+(deftest keyword->string
+  (testing "Conversion of keyword into a string"
+    (is "string" (kw->str "string"))
+    (is "key" (kw->str :key))
+    (is (thrown? IllegalArgumentException (kw->str [:x])))))
+
 (deftest vector-cons
   (is (= (vcons :this [[:a] [:b] [:c]])
          [:this [:a] [:b] [:c]])))
@@ -83,11 +89,11 @@
 
 (deftest get-tool-steps
   (testing "Getting the tool steps of a Galaxy workflow"
-     (let [wf (parse-ga snvphyl-ga)
-           t-steps (tool-steps wf)]
-       (is (= (count t-steps) 17))
-       (is (= (map get-id t-steps) (range 2 19))))
-     (let [wf (parse-ga asm-ga)
-           t-steps (tool-steps wf)]
-       (is (= (count t-steps) 6))
-       (is (= (map get-id t-steps) (range 1 7))))))
+    (let [wf (parse-ga snvphyl-ga)
+          t-steps (tool-steps wf)]
+      (is (= (count t-steps) 17))
+      (is (= (map get-id t-steps) (range 2 19))))
+    (let [wf (parse-ga asm-ga)
+          t-steps (tool-steps wf)]
+      (is (= (count t-steps) 6))
+      (is (= (map get-id t-steps) (range 1 7))))))

--- a/test/irida_wf_ga2xml/util_test.clj
+++ b/test/irida_wf_ga2xml/util_test.clj
@@ -27,6 +27,12 @@
   (is (= (vcons :this [[:a] [:b] [:c]])
          [:this [:a] [:b] [:c]])))
 
+(deftest make-safe-workflow-name
+  (is (= (safe-workflow-name "Some \t Crazy *&(^($*!@ Workflow     Name")
+         "SomeCrazyWorkflowName")
+      (= (safe-workflow-name "SISTR Analyze Reads v0.2")
+         "SISTRAnalyzeReadsv02")))
+
 (deftest x-in-coll
   (is (in? [1 2 3] 2))
   (is (in? ["a" "b" "c"] "c"))


### PR DESCRIPTION
- Added output directory cmdline opt for creating expected IRIDA workflow directory structure with `messages_en.properties`, `irida_workflow.xml`, and `irida_workflow_structure.ga`
- Extracting tool parameter labels from Galaxy tool XMLs for writing to messages file
- Optional extra attributes can be written to `toolParameter` tags in XML output from Galaxy tool XMLs 

### Files:
- [irida-wf-ga2xml-1.0.0-SNAPSHOT-standalone.zip](https://github.com/phac-nml/irida-wf-ga2xml/files/2284691/irida-wf-ga2xml-1.0.0-SNAPSHOT-standalone.zip) contains the compiled standalone jar at 6941c16b4b47f9b3f2bc52c7888367b40d5e20fc
- [SNVPhyl.zip](https://github.com/phac-nml/irida-wf-ga2xml/files/2284684/SNVPhyl.zip) contains the output directory from running `irida-wf-ga2xml` on the SNVPhyl Galaxy workflow v1.0.1 `*.ga` file. 
- [biohansel.zip](https://github.com/phac-nml/irida-wf-ga2xml/files/2276058/biohansel.zip) contains the `biohansel.ga` file for the `biohansel` example below
- [asm_annt.zip](https://github.com/phac-nml/irida-wf-ga2xml/files/2276062/asm_annt.zip) contains the `asm_annt.ga` file for the `AssemblyAnnotation` example below


### Example usage:

Basic pipeline:

```
$ java -jar irida-wf-ga2xml.jar -t biohansel -W 2.0.0 -i biohansel.ga -n biohansel -o /tmp

Wrote workflow XML to  /tmp/biohansel/2.0.0/irida_workflow.xml
Wrote Galaxy workflow *.ga file to  /tmp/biohansel/2.0.0/irida_workflow_structure.ga
Wrote IRIDA messages to  /tmp/biohansel/2.0.0/messages_en.properties
```

Contents of  `/tmp/biohansel/2.0.0/messages_en.properties`:
```properties
#Pipeline Info Properties
#Mon Aug 13 15:57:37 CDT 2018
pipeline.parameters.modal-title.biohansel=biohansel Pipeline Parameters
workflow.biohansel.description=
pipeline.h1.biohansel=biohansel Pipeline
pipeline.title.biohansel=Pipelines - biohansel
workflow.biohansel.title=biohansel Pipeline
#Tool Parameters - Tool: bio_hansel - Workflow Step #: 1
#Mon Aug 13 15:57:37 CDT 2018
pipeline.parameters.biohansel.bio_hansel-1-dev_args.use_json=Output JSON results
pipeline.parameters.biohansel.bio_hansel-1-qc_vals.max_intermediate_tiles=QC\: Decimal Proportion of max allowed missing tiles for an intermediate subtype
pipeline.parameters.biohansel.bio_hansel-1-qc_vals.min_ambiguous_tiles=QC\: Min number of tiles missing for Ambiguous Result
pipeline.parameters.biohansel.bio_hansel-1-kmer_vals.kmer_min=Min k-mer frequency/coverage
pipeline.parameters.biohansel.bio_hansel-1-qc_vals.max_missing_tiles=QC\: Decimal Proportion of max allowed missing tiles
pipeline.parameters.biohansel.bio_hansel-1-qc_vals.low_coverage_warning=QC\: Overall tile coverage below this value will trigger a low coverage warning
pipeline.parameters.biohansel.bio_hansel-1-kmer_vals.kmer_max=Max k-mer frequency/coverage
pipeline.parameters.biohansel.bio_hansel-1-qc_vals.low_cov_depth_freq=QC\: Frequency below this coverage are considered low coverage
pipeline.parameters.biohansel.bio_hansel-1-type_of_scheme.scheme_type=Specify scheme to use. (Heidelberg is default)
```

Pipeline with a few steps:

```
$ java -jar irida-wf-ga2xml.jar -t assembly -W 1.0.0 -i asm_annt.ga -n AssemblyAnnotation -o /tmp

Wrote workflow XML to  /tmp/AssemblyAnnotation/1.0.0/irida_workflow.xml
Wrote Galaxy workflow *.ga file to  /tmp/AssemblyAnnotation/1.0.0/irida_workflow_structure.ga
Wrote IRIDA messages to  /tmp/AssemblyAnnotation/1.0.0/messages_en.properties
```

Contents of `/tmp/AssemblyAnnotation/1.0.0/messages_en.properties`
```properties
#Pipeline Info Properties
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.modal-title.AssemblyAnnotation=AssemblyAnnotation Pipeline Parameters
workflow.asm_annt.title=AssemblyAnnotation Pipeline
pipeline.h1.AssemblyAnnotation=AssemblyAnnotation Pipeline
pipeline.title.AssemblyAnnotation=Pipelines - AssemblyAnnotation
workflow.asm_annt.description=
#Tool Parameters - Tool: flash - Workflow Step #: 1
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.flash-1-max_overlap=Maximum overlap
pipeline.parameters.AssemblyAnnotation.flash-1-min_overlap=Minimum overlap
#Tool Parameters - Tool: spades - Workflow Step #: 2
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.spades-2-iontorrent=Libraries are IonTorrent reads?
pipeline.parameters.AssemblyAnnotation.spades-2-kmer_choice.auto_kmer_choice=Automatically choose k-mer values
pipeline.parameters.AssemblyAnnotation.spades-2-sc=Single-cell?
pipeline.parameters.AssemblyAnnotation.spades-2-onlyassembler=Run only assembly? (without read error correction)
pipeline.parameters.AssemblyAnnotation.spades-2-careful=Careful correction?
pipeline.parameters.AssemblyAnnotation.spades-2-cov.state=Coverage Cutoff
#Tool Parameters - Tool: regex_find_replace - Workflow Step #: 3
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.regex_find_replace-3-field.value=
#Tool Parameters - Tool: filter_spades_repeats - Workflow Step #: 4
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-keep_leftover=Print out a fasta file containing the discarded sequences?
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-len_cutoff=Length cut-off
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-print_summary=Print out a summary of all the results?
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-cov_cutoff=Coverage cut-off ratio
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-rep_cutoff=Repeat cut-off ratio
pipeline.parameters.AssemblyAnnotation.filter_spades_repeats-4-cov_len_cutoff=Length for average coverage calculation
#Tool Parameters - Tool: assemblystats - Workflow Step #: 5
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.assemblystats-5-all_outputs=Return all output files
pipeline.parameters.AssemblyAnnotation.assemblystats-5-bucket=Output histogram with bin sizes\=1
#Tool Parameters - Tool: prokka - Workflow Step #: 6
#Mon Aug 13 15:56:13 CDT 2018
pipeline.parameters.AssemblyAnnotation.prokka-6-gffver=GFF version (--gffver)
pipeline.parameters.AssemblyAnnotation.prokka-6-evalue=Similarity e-value cut-off
pipeline.parameters.AssemblyAnnotation.prokka-6-metagenome=Improve gene predictions for highly fragmented genomes (--metagenome)
pipeline.parameters.AssemblyAnnotation.prokka-6-fast=Fast mode (--fast)
pipeline.parameters.AssemblyAnnotation.prokka-6-plasmid=Plasmid name or identifier (--plasmid)
pipeline.parameters.AssemblyAnnotation.prokka-6-species=Species name (--species)
pipeline.parameters.AssemblyAnnotation.prokka-6-compliant.compliant_select=Force GenBank/ENA/DDJB compliance (--compliant)
pipeline.parameters.AssemblyAnnotation.prokka-6-genus=Genus name (--genus)
pipeline.parameters.AssemblyAnnotation.prokka-6-norrna=Don't run rRNA search with Barrnap
pipeline.parameters.AssemblyAnnotation.prokka-6-increment=Locus tag counter increment (--increment)
pipeline.parameters.AssemblyAnnotation.prokka-6-centre=Sequencing centre ID (--centre)
pipeline.parameters.AssemblyAnnotation.prokka-6-kingdom.kingdom_select=Kingdom (--kingdom)
pipeline.parameters.AssemblyAnnotation.prokka-6-rfam=Enable searching for ncRNAs with Infernal+Rfam (SLOW\!) (--rfam)
pipeline.parameters.AssemblyAnnotation.prokka-6-notrna=Don't run tRNA search with Aragorn
pipeline.parameters.AssemblyAnnotation.prokka-6-usegenus=Use genus-specific BLAST database (--usegenus)
pipeline.parameters.AssemblyAnnotation.prokka-6-locustag=Locus tag prefix (--locustag)
pipeline.parameters.AssemblyAnnotation.prokka-6-strain=Strain name (--strain)
pipeline.parameters.AssemblyAnnotation.prokka-6-kingdom.gcode=Genetic code (transl_table)
```