### PR TITLE
irida_workflow.xml now uses uuid for toolParameter toolId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Changes
+======
+
+1.0.0 to 1.1.0
+--------------
+* [Feature]: Added option `-u`/`--uuid-as-toolid`to use uuid when generating tool IDs. This is needed when a workflow has multiple of the same tool.
+* [Documentation]: Added information on how to get started with Leiningen
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,6 @@ Changes
 
 1.0.0 to 1.1.0
 --------------
-* [Feature]: Added option `-u`/`--uuid-as-toolid`to use uuid when generating tool IDs. This is needed when a workflow has multiple of the same tool.
+* [Feature]: Added option `-u`/`--use-tool-name-as-id` Use tool names when building tool_ids, will not work with workflows that have multiple of the same tool.
 * [Documentation]: Added information on how to get started with Leiningen
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Execute standalone JAR with `java`:
       -i, --input INPUT                                 Galaxy workflow ga JSON format file
       -x, --extra-tool-param-attrs                      Save extra toolParameter attributes ["label", "type"] to XML
           --remove-output-name-file-ext                 Remove file extension in workflow output names?
+      -u, --uuid-as-toolid                              Use UUID when building tool_ids, needed for workflows with duplicate tools.
       -v, --verbosity                                   Verbosity level
       -V, --version                                     Display version
       -h, --help
@@ -47,6 +48,20 @@ Execute standalone JAR with `java`:
 - `-o`/`--outdir`: Output directory; where to create the `<workflow-name>/<workflow-version>/` directory structure and write the `irida_workflow.xml`, `irida_workflow_structure.ga` and `messages_en.properties` files
 - `-x`/`--extra-tool-param-attrs`: Save extra toolParameter attributes `["label", "type"]` to XML `toolParameter` tags
 - `--remove-output-name-file-ext`: Remove file extension in workflow output names? (default is to keep the extensions in the `<output>` tag names)
+- `-u`/`--uuid-as-toolid`: Use UUID when building tool_ids, needed for workflows with duplicate tools.
+
+
+## Getting started with Leiningen
+
+Make sure you have the latest version of Leiningen downloaded. Instructions available here: https://leiningen.org/
+
+You can run the project using Leiningen with the following example:
+
+`lein run project.clj --input my_workflow.ga --outdir output_directory/`
+
+You can run the test suite with the following command:
+
+`lein test`
 
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Execute standalone JAR with `java`:
       -i, --input INPUT                                 Galaxy workflow ga JSON format file
       -x, --extra-tool-param-attrs                      Save extra toolParameter attributes ["label", "type"] to XML
           --remove-output-name-file-ext                 Remove file extension in workflow output names?
-      -u, --uuid-as-toolid                              Use UUID when building tool_ids, needed for workflows with duplicate tools.
+      -u, --use-tool-name-as-id                         Use tool names when building tool_ids, will not work with workflows that have multiple of the same tool
       -v, --verbosity                                   Verbosity level
       -V, --version                                     Display version
       -h, --help
@@ -48,7 +48,7 @@ Execute standalone JAR with `java`:
 - `-o`/`--outdir`: Output directory; where to create the `<workflow-name>/<workflow-version>/` directory structure and write the `irida_workflow.xml`, `irida_workflow_structure.ga` and `messages_en.properties` files
 - `-x`/`--extra-tool-param-attrs`: Save extra toolParameter attributes `["label", "type"]` to XML `toolParameter` tags
 - `--remove-output-name-file-ext`: Remove file extension in workflow output names? (default is to keep the extensions in the `<output>` tag names)
-- `-u`/`--uuid-as-toolid`: Use UUID when building tool_ids, needed for workflows with duplicate tools.
+- `-u`/`--use-tool-name-as-id`: Use tool names when building tool_ids, will not work with workflows that have multiple of the same tool.
 
 
 ## Getting started with Leiningen

--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ This JVM application creates a XML workflow description (`irida_structure.xml`) 
 - Java 1.8 must be installed 
 - Download [latest standalone release of `irida-wf-ga2xml`](https://github.com/phac-nml/irida-wf-ga2xml/releases)
 
+### Build from source
+
+Ensure that Java 1.8 (or higher), [Clojure] and [lein] are installed on your system. Clone this repo and use `lein` to build an uberjar file:
+
+```bash
+git clone https://github.com/phac-nml/irida-wf-ga2xml
+cd irida-wf-ga2xml
+# optionally, run tests
+lein test
+# build uberjar
+lein uberjar
+# run the application
+lein run project.clj --input my_workflow.ga --outdir output_directory/
+```
+
+The uberjar files will be created in `target/uberjar/`.
+The standalone JAR file is likely the one you want to use and will have a filename like `irida-wf-ga2xml-1.1.0-SNAPSHOT-standalone.jar`.
+
+[Clojure]: https://www.clojure.org/guides/getting_started
+[lein]: https://leiningen.org/
+
 ## Usage
 
 Execute standalone JAR with `java`:
@@ -49,20 +70,6 @@ Execute standalone JAR with `java`:
 - `-x`/`--extra-tool-param-attrs`: Save extra toolParameter attributes `["label", "type"]` to XML `toolParameter` tags
 - `--remove-output-name-file-ext`: Remove file extension in workflow output names? (default is to keep the extensions in the `<output>` tag names)
 - `-u`/`--use-tool-name-as-id`: Use tool names when building tool_ids, will not work with workflows that have multiple of the same tool.
-
-
-## Getting started with Leiningen
-
-Make sure you have the latest version of Leiningen downloaded. Instructions available here: https://leiningen.org/
-
-You can run the project using Leiningen with the following example:
-
-`lein run project.clj --input my_workflow.ga --outdir output_directory/`
-
-You can run the test suite with the following command:
-
-`lein test`
-
 
 ## Examples
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject irida-wf-ga2xml "1.1.0-SNAPSHOT"
+(defproject irida-wf-ga2xml "1.1.0"
   :description "Parse a Galaxy workflow ga JSON file and output an IRIDA workflow description XML file"
   :url "https://github.com/phac-nml/irida-wf-ga2xml"
   :license {:name "Apache License 2.0"

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -58,10 +58,10 @@
   serialize into the expected IRIDA XML format for tool parameters."
   [step & {:keys [get-param-labels?
                   extra-tool-param-attrs?
-                  uuid-as-toolid?]
+                  use-tool-name-as-id?]
            :or   {get-param-labels?       true
                   extra-tool-param-attrs? false
-                  uuid-as-toolid?         false}}]
+                  use-tool-name-as-id?    false}}]
   (let [{:strs [tool_id id uuid]} step
         {:keys [name]} (tool-id->repo-info tool_id)
         params (tool-params-map step)
@@ -69,7 +69,7 @@
                       (msgs/get-tool-param-values step (keys params))
                       nil)
         xml-vec (vec (map (fn [[k v]]
-                            (let [base-attrs {:toolId        (if uuid-as-toolid? uuid tool_id)
+                            (let [base-attrs {:toolId        (if use-tool-name-as-id? tool_id uuid)
                                               :parameterName k}
                                   extra-attrs (if extra-tool-param-attrs?
                                                 (map (fn [x]
@@ -110,7 +110,7 @@
                           ^Boolean output-messages?
                           ^Boolean extra-tool-param-attrs?
                           ^Boolean remove-output-name-file-ext?
-                          ^Boolean uuid-as-toolid?]
+                          ^Boolean use-tool-name-as-id?]
                    :or   {single-sample?               true
                           wf-version                   "0.1.0"
                           analysis-type                "DEFAULT"
@@ -119,7 +119,7 @@
                           output-messages?             true
                           extra-tool-param-attrs?      false
                           remove-output-name-file-ext? false
-                          uuid-as-toolid?                    false}}]
+                          use-tool-name-as-id?         false}}]
   (let [ga-map (parse-ga path)
         {:strs [name annotation]} ga-map
         _ (info (str "Parsed Galaxy workflow file with name='" name "' and annotation/description='" annotation "'"))
@@ -133,7 +133,7 @@
                              (map #(tool-params-vec %
                                                     :get-param-labels? output-messages?
                                                     :extra-tool-param-attrs? extra-tool-param-attrs?
-                                                    :uuid-as-toolid? uuid-as-toolid?))
+                                                    :use-tool-name-as-id? use-tool-name-as-id?))
                              (filter not-empty))
         out {:name name
              :xml-vec

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -57,9 +57,11 @@
   "Return a vector of all tool parameters for a workflow `step` in a format that will
   serialize into the expected IRIDA XML format for tool parameters."
   [step & {:keys [get-param-labels?
-                  extra-tool-param-attrs?]
+                  extra-tool-param-attrs?
+                  uuid-as-toolid?]
            :or   {get-param-labels?       true
-                  extra-tool-param-attrs? false}}]
+                  extra-tool-param-attrs? false
+                  uuid-as-toolid?         false}}]
   (let [{:strs [tool_id id uuid]} step
         {:keys [name]} (tool-id->repo-info tool_id)
         params (tool-params-map step)
@@ -67,7 +69,7 @@
                       (msgs/get-tool-param-values step (keys params))
                       nil)
         xml-vec (vec (map (fn [[k v]]
-                            (let [base-attrs {:toolId        uuid
+                            (let [base-attrs {:toolId        (if uuid-as-toolid? uuid tool_id)
                                               :parameterName k}
                                   extra-attrs (if extra-tool-param-attrs?
                                                 (map (fn [x]
@@ -107,7 +109,8 @@
                           ^String wf-id
                           ^Boolean output-messages?
                           ^Boolean extra-tool-param-attrs?
-                          ^Boolean remove-output-name-file-ext?]
+                          ^Boolean remove-output-name-file-ext?
+                          ^Boolean uuid-as-toolid?]
                    :or   {single-sample?               true
                           wf-version                   "0.1.0"
                           analysis-type                "DEFAULT"
@@ -115,7 +118,8 @@
                           wf-id                        (uuid)
                           output-messages?             true
                           extra-tool-param-attrs?      false
-                          remove-output-name-file-ext? false}}]
+                          remove-output-name-file-ext? false
+                          uuid-as-toolid?                    false}}]
   (let [ga-map (parse-ga path)
         {:strs [name annotation]} ga-map
         _ (info (str "Parsed Galaxy workflow file with name='" name "' and annotation/description='" annotation "'"))
@@ -128,7 +132,8 @@
         parameters-maps (->> steps
                              (map #(tool-params-vec %
                                                     :get-param-labels? output-messages?
-                                                    :extra-tool-param-attrs? extra-tool-param-attrs?))
+                                                    :extra-tool-param-attrs? extra-tool-param-attrs?
+                                                    :uuid-as-toolid? uuid-as-toolid?))
                              (filter not-empty))
         out {:name name
              :xml-vec

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -60,14 +60,14 @@
                   extra-tool-param-attrs?]
            :or   {get-param-labels?       true
                   extra-tool-param-attrs? false}}]
-  (let [{:strs [tool_id id]} step
+  (let [{:strs [tool_id id uuid]} step
         {:keys [name]} (tool-id->repo-info tool_id)
         params (tool-params-map step)
         param-attrs (if get-param-labels?
                       (msgs/get-tool-param-values step (keys params))
                       nil)
         xml-vec (vec (map (fn [[k v]]
-                            (let [base-attrs {:toolId        tool_id
+                            (let [base-attrs {:toolId        uuid
                                               :parameterName k}
                                   extra-attrs (if extra-tool-param-attrs?
                                                 (map (fn [x]

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -34,7 +34,7 @@
    ["-i" "--input INPUT" "Galaxy workflow ga JSON format file"]
    ["-x" "--extra-tool-param-attrs" "Save extra toolParameter attributes [\"label\", \"type\"] to XML"]
    [nil "--remove-output-name-file-ext" "Remove file extension in workflow output names?"]
-   ["-u" "--uuid-as-toolid" "Use UUID when building tool_ids, needed for workflows with duplicate tools."]
+   ["-u" "--use-tool-name-as-id" "Use tool names when building tool_ids, will not work with workflows that have multiple of the same tool."]
    ["-v" "--verbosity" "Verbosity level"
     :id :verbosity
     :default 0
@@ -101,7 +101,7 @@
                     workflow-name
                     extra-tool-param-attrs
                     remove-output-name-file-ext
-                    uuid-as-toolid
+                    use-tool-name-as-id
                     verbosity]} options
             _ (timbre/set-level! (verbosity->logging-level verbosity))
             _ (trace "Options" options)
@@ -114,7 +114,7 @@
                                     :wf-name workflow-name
                                     :extra-tool-param-attrs? (boolean extra-tool-param-attrs)
                                     :remove-output-name-file-ext? (boolean remove-output-name-file-ext)
-                                    :uuid-as-toolid? (boolean uuid-as-toolid))
+                                    :use-tool-name-as-id? (boolean use-tool-name-as-id))
             _ (trace "irida-wf-map: " irida-wf-map)
             xml-str (vec->indented-xml (:xml-vec irida-wf-map))]
         (if outdir

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -34,6 +34,7 @@
    ["-i" "--input INPUT" "Galaxy workflow ga JSON format file"]
    ["-x" "--extra-tool-param-attrs" "Save extra toolParameter attributes [\"label\", \"type\"] to XML"]
    [nil "--remove-output-name-file-ext" "Remove file extension in workflow output names?"]
+   ["-u" "--uuid-as-toolid" "Use UUID when building tool_ids, needed for workflows with duplicate tools."]
    ["-v" "--verbosity" "Verbosity level"
     :id :verbosity
     :default 0
@@ -100,6 +101,7 @@
                     workflow-name
                     extra-tool-param-attrs
                     remove-output-name-file-ext
+                    uuid-as-toolid
                     verbosity]} options
             _ (timbre/set-level! (verbosity->logging-level verbosity))
             _ (trace "Options" options)
@@ -111,7 +113,8 @@
                                     :single-sample? (not multi-sample)
                                     :wf-name workflow-name
                                     :extra-tool-param-attrs? (boolean extra-tool-param-attrs)
-                                    :remove-output-name-file-ext? (boolean remove-output-name-file-ext))
+                                    :remove-output-name-file-ext? (boolean remove-output-name-file-ext)
+                                    :uuid-as-toolid? (boolean uuid-as-toolid))
             _ (trace "irida-wf-map: " irida-wf-map)
             xml-str (vec->indented-xml (:xml-vec irida-wf-map))]
         (if outdir

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -160,30 +160,30 @@
 (def sistr-cmd-step-new-tool-params
   [[:parameter
     {:name "sistr_cmd-1-keep_tmp", :defaultValue "false"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "keep_tmp"}]]
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "keep_tmp"}]]
    [:parameter
     {:name "sistr_cmd-1-output_format", :defaultValue "json"}
     [:toolParameter
-     {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "output_format"}]]
+     {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "output_format"}]]
    [:parameter
     {:name "sistr_cmd-1-run_mash", :defaultValue "true"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "run_mash"}]]
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "run_mash"}]]
    [:parameter
     {:name "sistr_cmd-1-more_output", :defaultValue "-MM"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "more_output"}]]
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "more_output"}]]
    [:parameter
     {:name "sistr_cmd-1-verbosity", :defaultValue "-vv"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "verbosity"}]]
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "verbosity"}]]
    [:parameter
     {:name "sistr_cmd-1-use_full_cgmlst_db", :defaultValue "false"}
     [:toolParameter
-     {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "use_full_cgmlst_db"}]]
+     {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "use_full_cgmlst_db"}]]
    [:parameter
     {:name "sistr_cmd-1-qc", :defaultValue "true"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "qc"}]]
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "qc"}]]
    [:parameter
     {:name "sistr_cmd-1-no_cgmlst", :defaultValue "false"}
-    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "no_cgmlst"}]]])
+    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "no_cgmlst"}]]])
 
 (def snvphyl-tool-steps (tool-steps (parse-ga snvphyl-ga)))
 
@@ -191,6 +191,94 @@
 (def snvphyl-cat-step (first (get (group-by #(get % "id") snvphyl-tool-steps) 13)))
 
 (def snvphyl-freebayes-step-tool-params
+  [[:parameter
+    {:name "freebayes-6-options_type.algorithmic_features.algorithmic_features_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.algorithmic_features.algorithmic_features_selector"}]]
+   [:parameter
+    {:name         "freebayes-6-options_type.population_mappability_priors.population_mappability_priors_selector",
+     :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_mappability_priors.population_mappability_priors_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.reference_allele.reference_allele_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.reference_allele.reference_allele_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.population_model.T", :defaultValue "0.001"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_model.T"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.input_filters.input_filters_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.input_filters.input_filters_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.population_model.population_model_selector", :defaultValue "True"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_model.population_model_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.optional_inputs.optional_inputs_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.optional_inputs.optional_inputs_selector"}]]
+   [:parameter
+    {:name "freebayes-6-reference_source.reference_source_selector", :defaultValue "history"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "reference_source.reference_source_selector"}]]
+   [:parameter
+    {:name "freebayes-6-target_limit_type.target_limit_type_selector", :defaultValue "do_not_limit"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "target_limit_type.target_limit_type_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.population_model.J", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_model.J"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.population_model.K", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_model.K"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.genotype_likelihoods.genotype_likelihoods_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.genotype_likelihoods.genotype_likelihoods_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.O", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.O"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.options_type_selector", :defaultValue "full"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.options_type_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.reporting.reporting_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.reporting.reporting_selector"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.population_model.P", :defaultValue "1"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.population_model.P"}]]
+   [:parameter
+    {:name "freebayes-6-options_type.allele_scope.allele_scope_selector", :defaultValue "False"}
+    [:toolParameter
+     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+      :parameterName "options_type.allele_scope.allele_scope_selector"}]]])
+
+(def snvphyl-freebayes-step-tool-params-uuid
   [[:parameter
     {:name "freebayes-6-options_type.algorithmic_features.algorithmic_features_selector", :defaultValue "False"}
     [:toolParameter
@@ -317,6 +405,11 @@
     (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false))
            snvphyl-freebayes-step-tool-params))))
 
+(deftest parse-tool-params-uuid
+  (testing "Parsing of SNVPhyl FreeBayes with uuid instead of toolid."
+    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false :uuid-as-toolid? true))
+            snvphyl-freebayes-step-tool-params-uuid))))
+
 (deftest workflow-to-vector
   (testing "Parsing of basic sistr_cmd workflow with FASTA input"
     (let [wf (:xml-vec (to-wf-vec basic-wf-ga :output-messages? false))]
@@ -370,3 +463,4 @@
   (let [flash-shed-info (util/tool-repo sistr-flash-step)]
     (is (= (vec->indented-xml flash-shed-info)
            sistr-flash-step-repo-xml))))
+

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -160,30 +160,30 @@
 (def sistr-cmd-step-new-tool-params
   [[:parameter
     {:name "sistr_cmd-1-keep_tmp", :defaultValue "false"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "keep_tmp"}]]
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "keep_tmp"}]]
    [:parameter
     {:name "sistr_cmd-1-output_format", :defaultValue "json"}
     [:toolParameter
-     {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "output_format"}]]
+     {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "output_format"}]]
    [:parameter
     {:name "sistr_cmd-1-run_mash", :defaultValue "true"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "run_mash"}]]
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "run_mash"}]]
    [:parameter
     {:name "sistr_cmd-1-more_output", :defaultValue "-MM"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "more_output"}]]
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "more_output"}]]
    [:parameter
     {:name "sistr_cmd-1-verbosity", :defaultValue "-vv"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "verbosity"}]]
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "verbosity"}]]
    [:parameter
     {:name "sistr_cmd-1-use_full_cgmlst_db", :defaultValue "false"}
     [:toolParameter
-     {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "use_full_cgmlst_db"}]]
+     {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "use_full_cgmlst_db"}]]
    [:parameter
     {:name "sistr_cmd-1-qc", :defaultValue "true"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "qc"}]]
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "qc"}]]
    [:parameter
     {:name "sistr_cmd-1-no_cgmlst", :defaultValue "false"}
-    [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "no_cgmlst"}]]])
+    [:toolParameter {:toolId "7aa0fb20-be4c-4821-a60c-ba1e13a02ec9", :parameterName "no_cgmlst"}]]])
 
 (def snvphyl-tool-steps (tool-steps (parse-ga snvphyl-ga)))
 
@@ -194,88 +194,88 @@
   [[:parameter
     {:name "freebayes-6-options_type.algorithmic_features.algorithmic_features_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.algorithmic_features.algorithmic_features_selector"}]]
    [:parameter
     {:name         "freebayes-6-options_type.population_mappability_priors.population_mappability_priors_selector",
      :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_mappability_priors.population_mappability_priors_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.reference_allele.reference_allele_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.reference_allele.reference_allele_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.population_model.T", :defaultValue "0.001"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_model.T"}]]
    [:parameter
     {:name "freebayes-6-options_type.input_filters.input_filters_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.input_filters.input_filters_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.population_model.population_model_selector", :defaultValue "True"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_model.population_model_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.optional_inputs.optional_inputs_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.optional_inputs.optional_inputs_selector"}]]
    [:parameter
     {:name "freebayes-6-reference_source.reference_source_selector", :defaultValue "history"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "reference_source.reference_source_selector"}]]
    [:parameter
     {:name "freebayes-6-target_limit_type.target_limit_type_selector", :defaultValue "do_not_limit"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "target_limit_type.target_limit_type_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.population_model.J", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_model.J"}]]
    [:parameter
     {:name "freebayes-6-options_type.population_model.K", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_model.K"}]]
    [:parameter
     {:name "freebayes-6-options_type.genotype_likelihoods.genotype_likelihoods_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.genotype_likelihoods.genotype_likelihoods_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.O", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.O"}]]
    [:parameter
     {:name "freebayes-6-options_type.options_type_selector", :defaultValue "full"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.options_type_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.reporting.reporting_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.reporting.reporting_selector"}]]
    [:parameter
     {:name "freebayes-6-options_type.population_model.P", :defaultValue "1"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.population_model.P"}]]
    [:parameter
     {:name "freebayes-6-options_type.allele_scope.allele_scope_selector", :defaultValue "False"}
     [:toolParameter
-     {:toolId        "irida.corefacility.ca/galaxy-shed/repos/devteam/freebayes/freebayes/0.4.1",
+     {:toolId        "880cb192-d299-4736-af89-2b0df9977514",
       :parameterName "options_type.allele_scope.allele_scope_selector"}]]])
 
 (deftest tool-shed-repo-info-from-tool-id

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -157,7 +157,7 @@
    "content_id"           "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2",
    "tool_id"              "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2"})
 
-(def sistr-cmd-step-new-tool-params
+(def sistr-cmd-step-new-tool-params-tool-name
   [[:parameter
     {:name "sistr_cmd-1-keep_tmp", :defaultValue "false"}
     [:toolParameter {:toolId "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.0.2", :parameterName "keep_tmp"}]]
@@ -190,7 +190,7 @@
 (def snvphyl-freebayes-step (first (get (group-by #(get % "id") snvphyl-tool-steps) 6)))
 (def snvphyl-cat-step (first (get (group-by #(get % "id") snvphyl-tool-steps) 13)))
 
-(def snvphyl-freebayes-step-tool-params
+(def snvphyl-freebayes-step-tool-params-tool-name
   [[:parameter
     {:name "freebayes-6-options_type.algorithmic_features.algorithmic_features_selector", :defaultValue "False"}
     [:toolParameter
@@ -397,17 +397,17 @@
             [:-comment "WARNING: Latest revision fetched from https://toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd"]]))
     (is (nil? (util/tool-repo snvphyl-cat-step)))))
 
-(deftest parse-tool-params
+(deftest parse-tool-params-tool-name
   (testing "Parsing of sistr_cmd tool parameters."
-    (is (= (:xml-vec (tool-params-vec sistr-cmd-step-new :get-param-labels? false))
-           sistr-cmd-step-new-tool-params)))
+    (is (= (:xml-vec (tool-params-vec sistr-cmd-step-new :get-param-labels? false :use-tool-name-as-id? true))
+           sistr-cmd-step-new-tool-params-tool-name)))
   (testing "Parsing of SNVPhyl FreeBayes step deeply nested parameters."
-    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false))
-           snvphyl-freebayes-step-tool-params))))
+    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false :use-tool-name-as-id? true))
+           snvphyl-freebayes-step-tool-params-tool-name))))
 
 (deftest parse-tool-params-uuid
   (testing "Parsing of SNVPhyl FreeBayes with uuid instead of toolid."
-    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false :uuid-as-toolid? true))
+    (is (= (:xml-vec (tool-params-vec snvphyl-freebayes-step :get-param-labels? false))
             snvphyl-freebayes-step-tool-params-uuid))))
 
 (deftest workflow-to-vector


### PR DESCRIPTION
This change makes the tool use the uuid instead of the tool_id ( `irida_workflow_structure.ga` ) when generating the `toolId` in `toolParameter ` for the `irida_workflow.xml` output file.

This allows for generating xml's that have multiple of the same tool, without crashing IRIDA.