### PR TITLE
Be more flexible in finding reference data, update to match current Galaxy .ga format

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Command-line for creating SNVPhyl v1.0.1 workflow files:
 
     18-08-14 21:46:55 pk INFO [irida-wf-ga2xml.main:102] - Parsing  test/data/snvphyl-1.0.1-workflow.ga  Galaxy workflow file. Creating irida_workflow.xml with workflow name ' SNVPhyl ' and version ' 1.0.1 '.
     18-08-14 21:46:55 pk INFO [irida-wf-ga2xml.core:119] - Parsed Galaxy workflow file with name='SNVPhyl v1.0.1 Paired-End' and annotation/description='snvphyl'
-    18-08-14 21:46:55 pk INFO [irida-wf-ga2xml.core:121] - Using worklfow name='SNVPhyl'
+    18-08-14 21:46:55 pk INFO [irida-wf-ga2xml.core:121] - Using workflow name='SNVPhyl'
     18-08-14 21:46:56 pk INFO [irida-wf-ga2xml.core:123] - 16 input steps in workflow
     18-08-14 21:46:56 pk INFO [irida-wf-ga2xml.core:125] - 17 tool execution steps in workflow
     18-08-14 21:47:03 pk ERROR [irida-wf-ga2xml.messages:174] - Could not get tool parameter attribute info for {} ; Encountered error: java.io.FileNotFoundException: /repos/file (No such file or directory)

--- a/src/irida_wf_ga2xml/core.clj
+++ b/src/irida_wf_ga2xml/core.clj
@@ -124,7 +124,7 @@
         {:strs [name annotation]} ga-map
         _ (info (str "Parsed Galaxy workflow file with name='" name "' and annotation/description='" annotation "'"))
         name (safe-workflow-name (if wf-name wf-name name))
-        _ (info (str "Using worklfow name='" name "'"))
+        _ (info (str "Using workflow name='" name "'"))
         input (input-steps ga-map)
         _ (info (count input) "input steps in workflow")
         steps (tool-steps ga-map)

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -41,7 +41,7 @@
    "
   [repo-info]
   (let [{:keys [name owner url revision]} repo-info]
-    (util/slurp-nocheck-sslcert (str url "/repos/" owner "/" name "/file/" revision))))
+    (slurp (str url "/repos/" owner "/" name "/file/" revision))))
 
 (defn xml-filename
   [html]
@@ -69,7 +69,7 @@
   "Read and parse an XML file from a `url` and return a zipper for the parsed XML starting at the root element."
   [url]
   (-> url
-      util/slurp-nocheck-sslcert
+      slurp
       xml/parse-str
       zip/xml-zip))
 

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -128,9 +128,6 @@
           conditionals (iter-non-param-elements :conditional)]
       (into {} (concat params sections conditionals)))))
 
-
-
-
 (defn flatten-param-values-map
   "Flatten a nested tool param values map.
 

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -41,7 +41,7 @@
    "
   [repo-info]
   (let [{:keys [name owner url revision]} repo-info]
-    (slurp (str url "/repos/" owner "/" name "/file/" revision))))
+    (util/slurp-nocheck-sslcert (str url "/repos/" owner "/" name "/file/" revision))))
 
 (defn xml-filename
   [html]
@@ -65,12 +65,11 @@
   (let [{:keys [name url owner revision]} repo-info]
     (str url "/repos/" owner "/" name "/raw-file/" revision "/" filename)))
 
-
 (defn xml-url->zipper
   "Read and parse an XML file from a `url` and return a zipper for the parsed XML starting at the root element."
   [url]
   (-> url
-      slurp
+      util/slurp-nocheck-sslcert
       xml/parse-str
       zip/xml-zip))
 

--- a/src/irida_wf_ga2xml/messages.clj
+++ b/src/irida_wf_ga2xml/messages.clj
@@ -45,7 +45,7 @@
 
 (defn xml-filename
   [html]
-  (if-let [[_ filename] (re-find (re-pattern "class=\"filename\">\\s*<a href=\"\\S*\\/repos\\/\\w+\\/\\w+\\/file\\/\\w+\\/(\\w+\\.xml)\"") html)]
+  (if-let [[_ filename] (re-find (re-pattern "class=\"filename\">\\s*<a href=\"\\S*\\/repos\\/[A-Za-z0-9_-]+\\/[A-Za-z0-9_-]+\\/file\\/\\w+\\/([A-Za-z0-9_-]+\\.xml)\"") html)]
     filename
     nil))
 
@@ -76,7 +76,9 @@
 (defn name-kw
   "Get an XML `node` element's `:name` attribute as a keyword."
   [node]
-  (keyword (attr node :name)))
+  (keyword (if (nil? (attr node :name))  ; Galaxy parameters with argument attributes sometimes have no name attribute
+             (clojure.string/replace-first (attr node :argument) #"^-+" "") 
+             (attr node :name))))
 
 (defn get-param-values
   "Given an Galaxy tool XML `zipper`, get potentially nested map of param tag name attribute to `get-attr` attribute values (default :label).
@@ -157,21 +159,23 @@
   [repo-info & {:keys [attrs]
                 :or   {attrs [:label :type]}}]
   (try
-    (let [zipper (->> repo-info
+    (if (seq repo-info)  ; some steps (e.g. expression tools) don't have an associated tool repository
+      (let [zipper (->> repo-info
                       (get-toolshed-browse-html)
                       (xml-filename)
                       (raw-file-xml-url repo-info)
                       (xml-url->zipper))]
-      (into {} (map
-                 (fn [attr]
-                   {attr
-                    (-> zipper
-                        (get-param-values :attrs attr)
-                        (flatten-param-values-map))})
-                 attrs)))
-    (catch Exception e
-      (error "Could not get tool parameter attribute info for" repo-info "; Encountered error:" e)
-      nil)))
+        (into {} (map
+                (fn [attr]
+                  {attr
+                   (-> zipper
+                       (get-param-values :attrs attr)
+                       (flatten-param-values-map))})
+                attrs)))
+      {})  ; return empty map if the tool has no tool repository
+  (catch Exception e
+    (error "Could not get tool parameter attribute info for" repo-info "; Encountered error:" e)
+    nil)))
 
 (defn tool-step->param-attr-map
   "Given a Galaxy workflow `tool-step` map, get all tool param attributes from the Galaxy tool wrapper XML.

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -119,10 +119,12 @@
 
 (defn step-input-name-reference?
   "Is workflow step reference input file for a workflow that requires a reference file? (e.g. SNVPhyl)"
-  [{:strs [tool_state]}]
-  (let [tool_state (json/read-str tool_state)
+  [{:strs [tool_state name label]}]
+  (or (= name "reference")
+      (= label "reference")
+      (let [tool_state (json/read-str tool_state)
         {:strs [name]} tool_state]
-    (= name "reference")))
+        (= name "reference"))))
 
 (defn input-steps
   "Get \"data_input\"/\"data_collection_input\" type workflow steps.

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -32,9 +32,10 @@
                (.read input_stream buffer)
                (str text (apply str (map #(char (bit-and % 255)) (filter #(> % 0) buffer)))))))))
 
-(defn slurp-nocheck-sslcert [url] ; this is a replacement for the Clojure slurp function that doesn't check SSL certficates
-  (let [conn (.openConnection (java.net.URL. url))]
-    (set-socket-factory conn)
+(defn slurp-nocheck-sslcert [url] ; this is a replacement for the Clojure slurp function 
+  (let [conn (.openConnection (java.net.URL. url))] 
+    (if (.contains url "://irida.corefacility.ca") ; this ignores SSL certificate errors only for host irida.corefacility.ca
+      (set-socket-factory conn))
     (read_all_bytes (.getInputStream conn))))
 
 (def tool-id-repos-pattern (re-pattern "/repos/"))

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -21,10 +21,21 @@
     (.init sc nil cert-manager (java.security.SecureRandom.))
     (.setSSLSocketFactory conn (.getSocketFactory sc))))
 
+(defn read_all_bytes [input_stream]
+  (let [buffer_size 16384]
+    (loop [buffer (byte-array buffer_size)
+           bytes_read (.read input_stream buffer)
+           text (apply str (map #(char (bit-and % 255)) (filter #(> % 0) buffer)))]
+      (if (= bytes_read -1)
+        text
+        (recur (byte-array buffer_size)
+               (.read input_stream buffer)
+               (str text (apply str (map #(char (bit-and % 255)) (filter #(> % 0) buffer)))))))))
+
 (defn slurp-nocheck-sslcert [url] ; this is a replacement for the Clojure slurp function that doesn't check SSL certficates
   (let [conn (.openConnection (java.net.URL. url))]
     (set-socket-factory conn)
-    (String. (.readAllBytes (.getInputStream conn)))))
+    (read_all_bytes (.getInputStream conn))))
 
 (def tool-id-repos-pattern (re-pattern "/repos/"))
 (def slash-pattern (re-pattern "/"))

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -171,10 +171,10 @@
 
 (defn input-name
   "Name attribute of an input step from 'tool_state' map."
-  [{:strs [tool_state]}]
+  [{:strs [tool_state label]}]
   (let [tool_state (json/read-str tool_state)
         {:strs [name]} tool_state]
-    name))
+    (if (nil? name) label name)))
 
 (defn parameter-name
   "IRIDA workflow XML tool parameter name.

--- a/src/irida_wf_ga2xml/util.clj
+++ b/src/irida_wf_ga2xml/util.clj
@@ -244,7 +244,7 @@
    12 [a-f0-9] characters after '/rev/'"
   [url]
   (try
-    (let [html (slurp-nocheck-sslcert url)]
+    (let [html (slurp url)]
       (second (re-find #"/rev/([a-f0-9]{12})" html)))
     (catch Exception _
       nil)))

--- a/test/irida_wf_ga2xml/core_test.clj
+++ b/test/irida_wf_ga2xml/core_test.clj
@@ -57,9 +57,9 @@
                         "RenameDatasetActionlog_file"       {"action_arguments" {"newname" "flash.log"},
                                                              "action_type"      "RenameDatasetAction",
                                                              "output_name"      "log_file"}},
-   "tool_id"           "irida.corefacility.ca/galaxy-shed/repos/irida/flash/FLASH/1.3.0"})
+   "tool_id"           "testtoolshed.g2.bx.psu.edu/repos/aaronpetkau/flash/FLASH/1.3.0"})
 
-(def sistr-flash-step-repo-xml "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<repository>\n  <name>flash</name>\n  <owner>irida</owner>\n  <url>https://irida.corefacility.ca/galaxy-shed</url>\n  <revision>4287dd541327</revision>\n  <!--WARNING: Latest revision fetched from https://irida.corefacility.ca/galaxy-shed/repos/irida/flash-->\n</repository>\n")
+(def sistr-flash-step-repo-xml "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<repository>\n  <name>flash</name>\n  <owner>aaronpetkau</owner>\n  <url>https://testtoolshed.g2.bx.psu.edu</url>\n  <revision>b64409be8c69</revision>\n  <!--WARNING: Latest revision fetched from https://testtoolshed.g2.bx.psu.edu/repos/aaronpetkau/flash-->\n</repository>\n")
 
 (def sistr-cmd-step
   {"tool_errors"       nil,

--- a/test/irida_wf_ga2xml/messages_test.clj
+++ b/test/irida_wf_ga2xml/messages_test.clj
@@ -11,9 +11,9 @@
 
 (def flash-repo-info
   {:name     "flash"
-   :owner    "irida"
-   :revision "4287dd541327"
-   :url      "https://irida.corefacility.ca/galaxy-shed"})
+   :owner    "aaronpetkau"
+   :revision "b64409be8c69"
+   :url      "https://testtoolshed.g2.bx.psu.edu"})
 
 (def biohansel-repo-info
   {:owner    "nml"


### PR DESCRIPTION
This PR aims to address the problem reported in #4. The bug was triggered by the workflow that I am working on (https://github.com/pvanheus/irida-pipeline-plugins/tree/sample_0.3.0/snippy-tb-sample-iqtree).