### PR TITLE
Replace workflow name in .ga output

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject irida-wf-ga2xml "1.2.0"
+(defproject irida-wf-ga2xml "1.2.1"
   :description "Parse a Galaxy workflow ga JSON file and output an IRIDA workflow description XML file"
   :url "https://github.com/phac-nml/irida-wf-ga2xml"
   :license {:name "Apache License 2.0"

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -14,7 +14,7 @@
   (:gen-class))
 
 (def --program-- "irida-wf-ga2xml")
-(def --version-- "1.1.0")
+(def --version-- "1.2.1")
 
 (def cli-options
   [["-n" "--workflow-name WORKFLOW_NAME" "Workflow name (default is to extract name from workflow input file)"
@@ -125,7 +125,9 @@
             (io/make-parents ga-file-dest)
             (spit irida-xml-filename xml-str)
             (info "Wrote workflow XML to " irida-xml-filename)
-            (spit ga-file-dest (generate-string (assoc (decode (slurp input)) "name" workflow-name) {:pretty true}))
+            (let [workflow (decode (slurp input))
+                  workflow-name (if (nil? workflow-name) (get workflow "name") workflow-name)]
+                (spit ga-file-dest (generate-string (assoc workflow "name" workflow-name) {:pretty true})))
             (info "Wrote Galaxy workflow *.ga file to " ga-file-dest)
             (if-let [[main-props tool-param-props] (:props irida-wf-map)]
               (let [msg-props-file (.toString (file-with-base "messages_en.properties"))]

--- a/src/irida_wf_ga2xml/main.clj
+++ b/src/irida_wf_ga2xml/main.clj
@@ -125,7 +125,7 @@
             (io/make-parents ga-file-dest)
             (spit irida-xml-filename xml-str)
             (info "Wrote workflow XML to " irida-xml-filename)
-            (spit ga-file-dest (generate-string (decode (slurp input)) {:pretty true}))
+            (spit ga-file-dest (generate-string (assoc (decode (slurp input)) "name" workflow-name) {:pretty true}))
             (info "Wrote Galaxy workflow *.ga file to " ga-file-dest)
             (if-let [[main-props tool-param-props] (:props irida-wf-map)]
               (let [msg-props-file (.toString (file-with-base "messages_en.properties"))]


### PR DESCRIPTION
Fixes #5

Before writing the `irida_workflow_structure.ga` file, `assoc` the value of `workflow-name` to the `"name"` key in the output.